### PR TITLE
cleanup: remove feature segment from flags response

### DIFF
--- a/data/environment_n9fbf9h3v4fFgH3U3ngWhb.json
+++ b/data/environment_n9fbf9h3v4fFgH3U3ngWhb.json
@@ -311,8 +311,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -328,8 +327,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -345,8 +343,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -362,8 +359,7 @@
             "feature_state_value": "baz",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -379,8 +375,7 @@
             "feature_state_value": "segment_two_override_priority_0",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -433,8 +428,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -450,8 +444,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -467,8 +460,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -484,8 +476,7 @@
             "feature_state_value": "baz",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -501,8 +492,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -555,8 +545,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -572,8 +561,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -589,8 +577,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -606,8 +593,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -623,8 +609,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -677,8 +662,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -694,8 +678,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -711,8 +694,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -728,8 +710,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -745,8 +726,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -799,8 +779,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -816,8 +795,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -833,8 +811,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -850,8 +827,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -867,8 +843,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -921,8 +896,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -938,8 +912,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -955,8 +928,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -972,8 +944,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -989,8 +960,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -1043,8 +1013,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -1060,8 +1029,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -1077,8 +1045,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -1094,8 +1061,7 @@
             "feature_state_value": "bar",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -1111,8 +1077,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -1165,8 +1130,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -1182,8 +1146,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -1199,8 +1162,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -1216,8 +1178,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -1233,8 +1194,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -1287,8 +1247,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -1304,8 +1263,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -1321,8 +1279,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -1338,8 +1295,7 @@
             "feature_state_value": "bar",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -1355,8 +1311,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -1409,8 +1364,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -1426,8 +1380,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -1443,8 +1396,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -1460,8 +1412,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -1477,8 +1428,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -1531,8 +1481,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -1548,8 +1497,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -1565,8 +1513,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -1582,8 +1529,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -1599,8 +1545,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -1653,8 +1598,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -1670,8 +1614,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -1687,8 +1630,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -1704,8 +1646,7 @@
             "feature_state_value": "baz",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -1721,8 +1662,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -1775,8 +1715,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -1792,8 +1731,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -1809,8 +1747,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -1826,8 +1763,7 @@
             "feature_state_value": "bar",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -1843,8 +1779,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -1897,8 +1832,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -1914,8 +1848,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -1931,8 +1864,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -1948,8 +1880,7 @@
             "feature_state_value": "baz",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -1965,8 +1896,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -2019,8 +1949,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -2036,8 +1965,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -2053,8 +1981,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -2070,8 +1997,7 @@
             "feature_state_value": "bar",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 81027,
@@ -2087,8 +2013,7 @@
             "feature_state_value": "segment_override",
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": 9893
+            "identity": null
           }
         ]
       }
@@ -2141,8 +2066,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -2158,8 +2082,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -2175,8 +2098,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -2192,8 +2114,7 @@
             "feature_state_value": "baz",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -2209,8 +2130,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -2263,8 +2183,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -2280,8 +2199,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -2297,8 +2215,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -2314,8 +2231,7 @@
             "feature_state_value": "baz",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -2331,8 +2247,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -2385,8 +2300,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -2402,8 +2316,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -2419,8 +2332,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -2436,8 +2348,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -2453,8 +2364,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -2507,8 +2417,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -2524,8 +2433,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -2541,8 +2449,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -2558,8 +2465,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -2575,8 +2481,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -2629,8 +2534,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -2646,8 +2550,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -2663,8 +2566,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -2680,8 +2582,7 @@
             "feature_state_value": "bar",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -2697,8 +2598,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -2751,8 +2651,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -2768,8 +2667,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -2785,8 +2683,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -2802,8 +2699,7 @@
             "feature_state_value": "baz",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -2819,8 +2715,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -2873,8 +2768,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -2890,8 +2784,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -2907,8 +2800,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -2924,8 +2816,7 @@
             "feature_state_value": "baz",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -2941,8 +2832,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -2995,8 +2885,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -3012,8 +2901,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -3029,8 +2917,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -3046,8 +2933,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -3063,8 +2949,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -3117,8 +3002,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -3134,8 +3018,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -3151,8 +3034,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -3168,8 +3050,7 @@
             "feature_state_value": "bar",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -3185,8 +3066,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -3239,8 +3119,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -3256,8 +3135,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -3273,8 +3151,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -3290,8 +3167,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -3307,8 +3183,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -3361,8 +3236,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -3378,8 +3252,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -3395,8 +3268,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -3412,8 +3284,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -3429,8 +3300,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -3483,8 +3353,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -3500,8 +3369,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -3517,8 +3385,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -3534,8 +3401,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -3551,8 +3417,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -3605,8 +3470,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -3622,8 +3486,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -3639,8 +3502,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -3656,8 +3518,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -3673,8 +3534,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -3727,8 +3587,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -3744,8 +3603,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -3761,8 +3619,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -3778,8 +3635,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -3795,8 +3651,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -3849,8 +3704,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -3866,8 +3720,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -3883,8 +3736,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -3900,8 +3752,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 81027,
@@ -3917,8 +3768,7 @@
             "feature_state_value": "segment_override",
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": 9893
+            "identity": null
           }
         ]
       }
@@ -3971,8 +3821,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -3988,8 +3837,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -4005,8 +3853,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -4022,8 +3869,7 @@
             "feature_state_value": "bar",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -4039,8 +3885,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -4093,8 +3938,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -4110,8 +3954,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -4127,8 +3970,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -4144,8 +3986,7 @@
             "feature_state_value": "baz",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -4161,8 +4002,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -4215,8 +4055,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -4232,8 +4071,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -4249,8 +4087,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -4266,8 +4103,7 @@
             "feature_state_value": "bar",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -4283,8 +4119,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -4337,8 +4172,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -4354,8 +4188,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -4371,8 +4204,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -4388,8 +4220,7 @@
             "feature_state_value": "bar",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -4405,8 +4236,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -4459,8 +4289,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -4476,8 +4305,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -4493,8 +4321,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -4510,8 +4337,7 @@
             "feature_state_value": "bar",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -4527,8 +4353,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -4581,8 +4406,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -4598,8 +4422,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -4615,8 +4438,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -4632,8 +4454,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -4649,8 +4470,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -4703,8 +4523,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -4720,8 +4539,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -4737,8 +4555,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -4754,8 +4571,7 @@
             "feature_state_value": "bar",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -4771,8 +4587,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -4825,8 +4640,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -4842,8 +4656,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -4859,8 +4672,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -4876,8 +4688,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -4893,8 +4704,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -4947,8 +4757,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -4964,8 +4773,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -4981,8 +4789,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -4998,8 +4805,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -5015,8 +4821,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -5069,8 +4874,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -5086,8 +4890,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -5103,8 +4906,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -5120,8 +4922,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -5137,8 +4938,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -5191,8 +4991,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -5208,8 +5007,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -5225,8 +5023,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -5242,8 +5039,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -5259,8 +5055,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -5313,8 +5108,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -5330,8 +5124,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -5347,8 +5140,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -5364,8 +5156,7 @@
             "feature_state_value": "bar",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -5381,8 +5172,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -5435,8 +5225,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -5452,8 +5241,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -5469,8 +5257,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -5486,8 +5273,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -5503,8 +5289,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -5557,8 +5342,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -5574,8 +5358,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -5591,8 +5374,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -5608,8 +5390,7 @@
             "feature_state_value": "baz",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -5625,8 +5406,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -5679,8 +5459,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -5696,8 +5475,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -5713,8 +5491,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -5730,8 +5507,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -5747,8 +5523,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -5801,8 +5576,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -5818,8 +5592,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -5835,8 +5608,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -5852,8 +5624,7 @@
             "feature_state_value": "bar",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -5869,8 +5640,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -5923,8 +5693,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -5940,8 +5709,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -5957,8 +5725,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -5974,8 +5741,7 @@
             "feature_state_value": "baz",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -5991,8 +5757,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -6045,8 +5810,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -6062,8 +5826,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -6079,8 +5842,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -6096,8 +5858,7 @@
             "feature_state_value": "baz",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -6113,8 +5874,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -6167,8 +5927,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -6184,8 +5943,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -6201,8 +5959,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -6218,8 +5975,7 @@
             "feature_state_value": "baz",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -6235,8 +5991,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -6289,8 +6044,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -6306,8 +6060,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -6323,8 +6076,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -6340,8 +6092,7 @@
             "feature_state_value": "baz",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -6357,8 +6108,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -6411,8 +6161,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -6428,8 +6177,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -6445,8 +6193,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -6462,8 +6209,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -6479,8 +6225,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -6533,8 +6278,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -6550,8 +6294,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -6567,8 +6310,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -6584,8 +6326,7 @@
             "feature_state_value": "baz",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -6601,8 +6342,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -6655,8 +6395,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -6672,8 +6411,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -6689,8 +6427,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -6706,8 +6443,7 @@
             "feature_state_value": "baz",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -6723,8 +6459,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -6777,8 +6512,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -6794,8 +6528,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -6811,8 +6544,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -6828,8 +6560,7 @@
             "feature_state_value": "baz",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -6845,8 +6576,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -6899,8 +6629,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -6916,8 +6645,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -6933,8 +6661,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -6950,8 +6677,7 @@
             "feature_state_value": "bar",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -6967,8 +6693,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -7021,8 +6746,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -7038,8 +6762,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -7055,8 +6778,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -7072,8 +6794,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -7089,8 +6810,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -7143,8 +6863,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -7160,8 +6879,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -7177,8 +6895,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -7194,8 +6911,7 @@
             "feature_state_value": "baz",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -7211,8 +6927,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -7265,8 +6980,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -7282,8 +6996,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -7299,8 +7012,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -7316,8 +7028,7 @@
             "feature_state_value": "bar",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -7333,8 +7044,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -7387,8 +7097,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -7404,8 +7113,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -7421,8 +7129,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -7438,8 +7145,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -7455,8 +7161,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -7509,8 +7214,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -7526,8 +7230,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -7543,8 +7246,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -7560,8 +7262,7 @@
             "feature_state_value": "baz",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -7577,8 +7278,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -7631,8 +7331,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -7648,8 +7347,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -7665,8 +7363,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -7682,8 +7379,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -7699,8 +7395,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -7753,8 +7448,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -7770,8 +7464,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -7787,8 +7480,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -7804,8 +7496,7 @@
             "feature_state_value": "bar",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -7821,8 +7512,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -7875,8 +7565,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -7892,8 +7581,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -7909,8 +7597,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -7926,8 +7613,7 @@
             "feature_state_value": "baz",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -7943,8 +7629,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -7997,8 +7682,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -8014,8 +7698,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -8031,8 +7714,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -8048,8 +7730,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -8065,8 +7746,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -8119,8 +7799,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -8136,8 +7815,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -8153,8 +7831,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -8170,8 +7847,7 @@
             "feature_state_value": "baz",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -8187,8 +7863,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -8241,8 +7916,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -8258,8 +7932,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -8275,8 +7948,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -8292,8 +7964,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -8309,8 +7980,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -8363,8 +8033,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -8380,8 +8049,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -8397,8 +8065,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -8414,8 +8081,7 @@
             "feature_state_value": "bar",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -8431,8 +8097,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -8485,8 +8150,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -8502,8 +8166,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -8519,8 +8182,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -8536,8 +8198,7 @@
             "feature_state_value": "bar",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -8553,8 +8214,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -8607,8 +8267,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -8624,8 +8283,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -8641,8 +8299,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -8658,8 +8315,7 @@
             "feature_state_value": "bar",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -8675,8 +8331,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -8729,8 +8384,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -8746,8 +8400,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -8763,8 +8416,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -8780,8 +8432,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -8797,8 +8448,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -8851,8 +8501,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -8868,8 +8517,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -8885,8 +8533,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -8902,8 +8549,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -8919,8 +8565,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -8973,8 +8618,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -8990,8 +8634,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -9007,8 +8650,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -9024,8 +8666,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -9041,8 +8682,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -9095,8 +8735,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -9112,8 +8751,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -9129,8 +8767,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -9146,8 +8783,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -9163,8 +8799,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -9217,8 +8852,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -9234,8 +8868,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -9251,8 +8884,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -9268,8 +8900,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -9285,8 +8916,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -9339,8 +8969,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -9356,8 +8985,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -9373,8 +9001,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -9390,8 +9017,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -9407,8 +9033,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -9461,8 +9086,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -9478,8 +9102,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -9495,8 +9118,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -9512,8 +9134,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -9529,8 +9150,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -9583,8 +9203,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -9600,8 +9219,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -9617,8 +9235,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -9634,8 +9251,7 @@
             "feature_state_value": "baz",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -9651,8 +9267,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -9705,8 +9320,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -9722,8 +9336,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -9739,8 +9352,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -9756,8 +9368,7 @@
             "feature_state_value": "bar",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -9773,8 +9384,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -9827,8 +9437,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -9844,8 +9453,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -9861,8 +9469,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -9878,8 +9485,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -9895,8 +9501,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -9949,8 +9554,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -9966,8 +9570,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -9983,8 +9586,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -10000,8 +9602,7 @@
             "feature_state_value": "baz",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -10017,8 +9618,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -10071,8 +9671,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -10088,8 +9687,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -10105,8 +9703,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -10122,8 +9719,7 @@
             "feature_state_value": "baz",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -10139,8 +9735,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -10193,8 +9788,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -10210,8 +9804,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -10227,8 +9820,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -10244,8 +9836,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 81027,
@@ -10261,8 +9852,7 @@
             "feature_state_value": "segment_override",
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": 9893
+            "identity": null
           }
         ]
       }
@@ -10315,8 +9905,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -10332,8 +9921,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -10349,8 +9937,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -10366,8 +9953,7 @@
             "feature_state_value": "bar",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -10383,8 +9969,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -10437,8 +10022,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -10454,8 +10038,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -10471,8 +10054,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -10488,8 +10070,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -10505,8 +10086,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -10559,8 +10139,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -10576,8 +10155,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -10593,8 +10171,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -10610,8 +10187,7 @@
             "feature_state_value": "bar",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -10627,8 +10203,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -10681,8 +10256,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -10698,8 +10272,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -10715,8 +10288,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -10732,8 +10304,7 @@
             "feature_state_value": "bar",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -10749,8 +10320,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -10803,8 +10373,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -10820,8 +10389,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -10837,8 +10405,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -10854,8 +10421,7 @@
             "feature_state_value": "bar",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -10871,8 +10437,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -10925,8 +10490,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -10942,8 +10506,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -10959,8 +10522,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -10976,8 +10538,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -10993,8 +10554,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -11047,8 +10607,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -11064,8 +10623,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -11081,8 +10639,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -11098,8 +10655,7 @@
             "feature_state_value": "bar",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -11115,8 +10671,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -11169,8 +10724,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -11186,8 +10740,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -11203,8 +10756,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -11220,8 +10772,7 @@
             "feature_state_value": "baz",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -11237,8 +10788,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -11291,8 +10841,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -11308,8 +10857,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -11325,8 +10873,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -11342,8 +10889,7 @@
             "feature_state_value": "bar",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -11359,8 +10905,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -11413,8 +10958,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -11430,8 +10974,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -11447,8 +10990,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -11464,8 +11006,7 @@
             "feature_state_value": "bar",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -11481,8 +11022,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -11535,8 +11075,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -11552,8 +11091,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -11569,8 +11107,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -11586,8 +11123,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -11603,8 +11139,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -11657,8 +11192,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -11674,8 +11208,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -11691,8 +11224,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -11708,8 +11240,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -11725,8 +11256,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -11779,8 +11309,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -11796,8 +11325,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -11813,8 +11341,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -11830,8 +11357,7 @@
             "feature_state_value": "bar",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -11847,8 +11373,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -11901,8 +11426,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -11918,8 +11442,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -11935,8 +11458,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -11952,8 +11474,7 @@
             "feature_state_value": "bar",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -11969,8 +11490,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -12023,8 +11543,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -12040,8 +11559,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -12057,8 +11575,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -12074,8 +11591,7 @@
             "feature_state_value": "bar",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -12091,8 +11607,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -12145,8 +11660,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -12162,8 +11676,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -12179,8 +11692,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -12196,8 +11708,7 @@
             "feature_state_value": "bar",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -12213,8 +11724,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -12267,8 +11777,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -12284,8 +11793,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -12301,8 +11809,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -12318,8 +11825,7 @@
             "feature_state_value": "bar",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -12335,8 +11841,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -12389,8 +11894,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -12406,8 +11910,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -12423,8 +11926,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -12440,8 +11942,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -12457,8 +11958,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }
@@ -12511,8 +12011,7 @@
             "feature_state_value": null,
             "enabled": false,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78984,
@@ -12528,8 +12027,7 @@
             "feature_state_value": "12.34",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78980,
@@ -12545,8 +12043,7 @@
             "feature_state_value": 1234,
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78986,
@@ -12562,8 +12059,7 @@
             "feature_state_value": "bar",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           },
           {
             "id": 78978,
@@ -12579,8 +12075,7 @@
             "feature_state_value": "foo",
             "enabled": true,
             "environment": 12561,
-            "identity": null,
-            "feature_segment": null
+            "identity": null
           }
         ]
       }


### PR DESCRIPTION
`feature_segment` is now part of `feature_state` and is not an integer (like it was in some flags here), but since we don't use it, it's better to get rid of it than to update those integer values to none. 