### PR TITLE
feat: Add semver tests

### DIFF
--- a/test_cases/test_semver_equal_condition_satisfied__should_match.jsonc
+++ b/test_cases/test_semver_equal_condition_satisfied__should_match.jsonc
@@ -1,0 +1,45 @@
+{
+  // Given: A segment with EQUAL condition checking version equals "1.0.0" using semver format
+  // When: An evaluation context with an identity that has version = "1.0.0" (exact match)
+  // Then: The context should be considered part of the segment
+  "context": {
+    "environment": {
+      "key": "key",
+      "name": "Environment"
+    },
+    "identity": {
+      "identifier": "version_user",
+      "key": "key_version_user",
+      "traits": {
+        "app_version": "1.0.0"
+      }
+    },
+    "segments": {
+      "18": {
+        "key": "18",
+        "name": "segment_version_1_0_0",
+        "rules": [
+          {
+            "type": "ALL",
+            "conditions": [
+              {
+                "operator": "EQUAL",
+                "property": "app_version",
+                "value": "1.0.0:semver"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "result": {
+    "flags": {},
+    "segments": [
+      {
+        "key": "18",
+        "name": "segment_version_1_0_0"
+      }
+    ]
+  }
+}

--- a/test_cases/test_semver_equal_condition_satisfied__should_match.jsonc
+++ b/test_cases/test_semver_equal_condition_satisfied__should_match.jsonc
@@ -2,6 +2,7 @@
   // Given: A segment with EQUAL condition checking version equals "1.0.0" using semver format
   // When: An evaluation context with an identity that has version = "1.0.0" (exact match)
   // Then: The context should be considered part of the segment
+  "$schema": "https://raw.githubusercontent.com/Flagsmith/engine-test-data/refs/tags/v2.0.0/schema.json",
   "context": {
     "environment": {
       "key": "key",

--- a/test_cases/test_semver_equal_different_version__should_not_match.jsonc
+++ b/test_cases/test_semver_equal_different_version__should_not_match.jsonc
@@ -1,0 +1,40 @@
+{
+  // Given: A segment with EQUAL condition checking version equals "1.0.1" using semver format
+  // When: An evaluation context with an identity that has version "1.0.0" (different version)
+  // Then: The context should not be considered part of the segment
+  "context": {
+    "environment": {
+      "key": "key",
+      "name": "Environment"
+    },
+    "identity": {
+      "identifier": "different_version_user",
+      "key": "key_different_version_user",
+      "traits": {
+        "app_version": "1.0.0"
+      }
+    },
+    "segments": {
+      "43": {
+        "key": "43",
+        "name": "segment_version_different_equal",
+        "rules": [
+          {
+            "type": "ALL",
+            "conditions": [
+              {
+                "operator": "EQUAL",
+                "property": "app_version",
+                "value": "1.0.1:semver"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "result": {
+    "flags": {},
+    "segments": []
+  }
+}

--- a/test_cases/test_semver_equal_different_version__should_not_match.jsonc
+++ b/test_cases/test_semver_equal_different_version__should_not_match.jsonc
@@ -2,6 +2,7 @@
   // Given: A segment with EQUAL condition checking version equals "1.0.1" using semver format
   // When: An evaluation context with an identity that has version "1.0.0" (different version)
   // Then: The context should not be considered part of the segment
+  "$schema": "https://raw.githubusercontent.com/Flagsmith/engine-test-data/refs/tags/v2.0.0/schema.json",
   "context": {
     "environment": {
       "key": "key",

--- a/test_cases/test_semver_equal_invalid_format__should_not_match.jsonc
+++ b/test_cases/test_semver_equal_invalid_format__should_not_match.jsonc
@@ -1,0 +1,40 @@
+{
+  // Given: A segment with EQUAL condition checking version equals "1.0.0" using semver format
+  // When: An evaluation context with an identity that has an invalid semver format
+  // Then: The context should not be considered part of the segment
+  "context": {
+    "environment": {
+      "key": "key",
+      "name": "Environment"
+    },
+    "identity": {
+      "identifier": "invalid_semver_user",
+      "key": "key_invalid_semver_user",
+      "traits": {
+        "app_version": "not_a_semver"
+      }
+    },
+    "segments": {
+      "42": {
+        "key": "42",
+        "name": "segment_version_invalid_format",
+        "rules": [
+          {
+            "type": "ALL",
+            "conditions": [
+              {
+                "operator": "EQUAL",
+                "property": "app_version",
+                "value": "1.0.0:semver"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "result": {
+    "flags": {},
+    "segments": []
+  }
+}

--- a/test_cases/test_semver_equal_invalid_format__should_not_match.jsonc
+++ b/test_cases/test_semver_equal_invalid_format__should_not_match.jsonc
@@ -2,6 +2,7 @@
   // Given: A segment with EQUAL condition checking version equals "1.0.0" using semver format
   // When: An evaluation context with an identity that has an invalid semver format
   // Then: The context should not be considered part of the segment
+  "$schema": "https://raw.githubusercontent.com/Flagsmith/engine-test-data/refs/tags/v2.0.0/schema.json",
   "context": {
     "environment": {
       "key": "key",

--- a/test_cases/test_semver_greater_than_complex_build__should_match.jsonc
+++ b/test_cases/test_semver_greater_than_complex_build__should_match.jsonc
@@ -1,0 +1,45 @@
+{
+  // Given: A segment with GREATER_THAN condition checking version > "1.2.3-pre.2+build.4" using semver format
+  // When: An evaluation context with an identity that has version "1.2.4" (complex semver comparison)
+  // Then: The context should be considered part of the segment
+  "context": {
+    "environment": {
+      "key": "key",
+      "name": "Environment"
+    },
+    "identity": {
+      "identifier": "complex_semver_user",
+      "key": "key_complex_semver_user",
+      "traits": {
+        "app_version": "1.2.4"
+      }
+    },
+    "segments": {
+      "49": {
+        "key": "49",
+        "name": "segment_version_complex_semver",
+        "rules": [
+          {
+            "type": "ALL",
+            "conditions": [
+              {
+                "operator": "GREATER_THAN",
+                "property": "app_version",
+                "value": "1.2.3-pre.2+build.4:semver"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "result": {
+    "flags": {},
+    "segments": [
+      {
+        "key": "49",
+        "name": "segment_version_complex_semver"
+      }
+    ]
+  }
+}

--- a/test_cases/test_semver_greater_than_complex_build__should_match.jsonc
+++ b/test_cases/test_semver_greater_than_complex_build__should_match.jsonc
@@ -2,6 +2,7 @@
   // Given: A segment with GREATER_THAN condition checking version > "1.2.3-pre.2+build.4" using semver format
   // When: An evaluation context with an identity that has version "1.2.4" (complex semver comparison)
   // Then: The context should be considered part of the segment
+  "$schema": "https://raw.githubusercontent.com/Flagsmith/engine-test-data/refs/tags/v2.0.0/schema.json",
   "context": {
     "environment": {
       "key": "key",

--- a/test_cases/test_semver_greater_than_condition_satisfied__should_match.jsonc
+++ b/test_cases/test_semver_greater_than_condition_satisfied__should_match.jsonc
@@ -1,0 +1,45 @@
+{
+  // Given: A segment with GREATER_THAN condition checking version > "1.0.0" using semver format
+  // When: An evaluation context with an identity that has version = "1.0.1" (newer version)
+  // Then: The context should be considered part of the segment
+  "context": {
+    "environment": {
+      "key": "key",
+      "name": "Environment"
+    },
+    "identity": {
+      "identifier": "newer_version_user",
+      "key": "key_newer_version_user",
+      "traits": {
+        "app_version": "1.0.1"
+      }
+    },
+    "segments": {
+      "19": {
+        "key": "19",
+        "name": "segment_version_newer_than_1_0_0",
+        "rules": [
+          {
+            "type": "ALL",
+            "conditions": [
+              {
+                "operator": "GREATER_THAN",
+                "property": "app_version",
+                "value": "1.0.0:semver"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "result": {
+    "flags": {},
+    "segments": [
+      {
+        "key": "19",
+        "name": "segment_version_newer_than_1_0_0"
+      }
+    ]
+  }
+}

--- a/test_cases/test_semver_greater_than_condition_satisfied__should_match.jsonc
+++ b/test_cases/test_semver_greater_than_condition_satisfied__should_match.jsonc
@@ -2,6 +2,7 @@
   // Given: A segment with GREATER_THAN condition checking version > "1.0.0" using semver format
   // When: An evaluation context with an identity that has version = "1.0.1" (newer version)
   // Then: The context should be considered part of the segment
+  "$schema": "https://raw.githubusercontent.com/Flagsmith/engine-test-data/refs/tags/v2.0.0/schema.json",
   "context": {
     "environment": {
       "key": "key",

--- a/test_cases/test_semver_greater_than_inclusive_newer__should_match.jsonc
+++ b/test_cases/test_semver_greater_than_inclusive_newer__should_match.jsonc
@@ -2,6 +2,7 @@
   // Given: A segment with GREATER_THAN_INCLUSIVE condition checking version >= "1.0.0" using semver format
   // When: An evaluation context with an identity that has version "1.0.1" (newer version)
   // Then: The context should be considered part of the segment
+  "$schema": "https://raw.githubusercontent.com/Flagsmith/engine-test-data/refs/tags/v2.0.0/schema.json",
   "context": {
     "environment": {
       "key": "key",

--- a/test_cases/test_semver_greater_than_inclusive_newer__should_match.jsonc
+++ b/test_cases/test_semver_greater_than_inclusive_newer__should_match.jsonc
@@ -1,0 +1,45 @@
+{
+  // Given: A segment with GREATER_THAN_INCLUSIVE condition checking version >= "1.0.0" using semver format
+  // When: An evaluation context with an identity that has version "1.0.1" (newer version)
+  // Then: The context should be considered part of the segment
+  "context": {
+    "environment": {
+      "key": "key",
+      "name": "Environment"
+    },
+    "identity": {
+      "identifier": "newer_version_user",
+      "key": "key_newer_version_user",
+      "traits": {
+        "app_version": "1.0.1"
+      }
+    },
+    "segments": {
+      "54": {
+        "key": "54",
+        "name": "segment_version_gte_newer",
+        "rules": [
+          {
+            "type": "ALL",
+            "conditions": [
+              {
+                "operator": "GREATER_THAN_INCLUSIVE",
+                "property": "app_version",
+                "value": "1.0.0:semver"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "result": {
+    "flags": {},
+    "segments": [
+      {
+        "key": "54",
+        "name": "segment_version_gte_newer"
+      }
+    ]
+  }
+}

--- a/test_cases/test_semver_greater_than_inclusive_older__should_not_match.jsonc
+++ b/test_cases/test_semver_greater_than_inclusive_older__should_not_match.jsonc
@@ -1,0 +1,40 @@
+{
+  // Given: A segment with GREATER_THAN_INCLUSIVE condition checking version >= "1.2.0" using semver format
+  // When: An evaluation context with an identity that has version "1.0.1" (older version)
+  // Then: The context should not be considered part of the segment
+  "context": {
+    "environment": {
+      "key": "key",
+      "name": "Environment"
+    },
+    "identity": {
+      "identifier": "older_version_user",
+      "key": "key_older_version_user",
+      "traits": {
+        "app_version": "1.0.1"
+      }
+    },
+    "segments": {
+      "55": {
+        "key": "55",
+        "name": "segment_version_gte_older",
+        "rules": [
+          {
+            "type": "ALL",
+            "conditions": [
+              {
+                "operator": "GREATER_THAN_INCLUSIVE",
+                "property": "app_version",
+                "value": "1.2.0:semver"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "result": {
+    "flags": {},
+    "segments": []
+  }
+}

--- a/test_cases/test_semver_greater_than_inclusive_older__should_not_match.jsonc
+++ b/test_cases/test_semver_greater_than_inclusive_older__should_not_match.jsonc
@@ -2,6 +2,7 @@
   // Given: A segment with GREATER_THAN_INCLUSIVE condition checking version >= "1.2.0" using semver format
   // When: An evaluation context with an identity that has version "1.0.1" (older version)
   // Then: The context should not be considered part of the segment
+  "$schema": "https://raw.githubusercontent.com/Flagsmith/engine-test-data/refs/tags/v2.0.0/schema.json",
   "context": {
     "environment": {
       "key": "key",

--- a/test_cases/test_semver_greater_than_inclusive_same__should_match.jsonc
+++ b/test_cases/test_semver_greater_than_inclusive_same__should_match.jsonc
@@ -1,0 +1,45 @@
+{
+  // Given: A segment with GREATER_THAN_INCLUSIVE condition checking version >= "1.0.1" using semver format
+  // When: An evaluation context with an identity that has version "1.0.1" (same version)
+  // Then: The context should be considered part of the segment
+  "context": {
+    "environment": {
+      "key": "key",
+      "name": "Environment"
+    },
+    "identity": {
+      "identifier": "same_version_user",
+      "key": "key_same_version_user",
+      "traits": {
+        "app_version": "1.0.1"
+      }
+    },
+    "segments": {
+      "56": {
+        "key": "56",
+        "name": "segment_version_gte_same",
+        "rules": [
+          {
+            "type": "ALL",
+            "conditions": [
+              {
+                "operator": "GREATER_THAN_INCLUSIVE",
+                "property": "app_version",
+                "value": "1.0.1:semver"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "result": {
+    "flags": {},
+    "segments": [
+      {
+        "key": "56",
+        "name": "segment_version_gte_same"
+      }
+    ]
+  }
+}

--- a/test_cases/test_semver_greater_than_inclusive_same__should_match.jsonc
+++ b/test_cases/test_semver_greater_than_inclusive_same__should_match.jsonc
@@ -2,6 +2,7 @@
   // Given: A segment with GREATER_THAN_INCLUSIVE condition checking version >= "1.0.1" using semver format
   // When: An evaluation context with an identity that has version "1.0.1" (same version)
   // Then: The context should be considered part of the segment
+  "$schema": "https://raw.githubusercontent.com/Flagsmith/engine-test-data/refs/tags/v2.0.0/schema.json",
   "context": {
     "environment": {
       "key": "key",

--- a/test_cases/test_semver_greater_than_older_major__should_not_match.jsonc
+++ b/test_cases/test_semver_greater_than_older_major__should_not_match.jsonc
@@ -2,6 +2,7 @@
   // Given: A segment with GREATER_THAN condition checking version > "1.2.0" using semver format
   // When: An evaluation context with an identity that has version "1.0.1" (older major version)
   // Then: The context should not be considered part of the segment
+  "$schema": "https://raw.githubusercontent.com/Flagsmith/engine-test-data/refs/tags/v2.0.0/schema.json",
   "context": {
     "environment": {
       "key": "key",

--- a/test_cases/test_semver_greater_than_older_major__should_not_match.jsonc
+++ b/test_cases/test_semver_greater_than_older_major__should_not_match.jsonc
@@ -1,0 +1,40 @@
+{
+  // Given: A segment with GREATER_THAN condition checking version > "1.2.0" using semver format
+  // When: An evaluation context with an identity that has version "1.0.1" (older major version)
+  // Then: The context should not be considered part of the segment
+  "context": {
+    "environment": {
+      "key": "key",
+      "name": "Environment"
+    },
+    "identity": {
+      "identifier": "older_major_user",
+      "key": "key_older_major_user",
+      "traits": {
+        "app_version": "1.0.1"
+      }
+    },
+    "segments": {
+      "47": {
+        "key": "47",
+        "name": "segment_version_older_major",
+        "rules": [
+          {
+            "type": "ALL",
+            "conditions": [
+              {
+                "operator": "GREATER_THAN",
+                "property": "app_version",
+                "value": "1.2.0:semver"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "result": {
+    "flags": {},
+    "segments": []
+  }
+}

--- a/test_cases/test_semver_greater_than_prerelease__should_match.jsonc
+++ b/test_cases/test_semver_greater_than_prerelease__should_match.jsonc
@@ -2,6 +2,7 @@
   // Given: A segment with GREATER_THAN condition checking version > "1.0.0-beta" using semver format
   // When: An evaluation context with an identity that has version "1.0.0" (release vs pre-release)
   // Then: The context should be considered part of the segment
+  "$schema": "https://raw.githubusercontent.com/Flagsmith/engine-test-data/refs/tags/v2.0.0/schema.json",
   "context": {
     "environment": {
       "key": "key",

--- a/test_cases/test_semver_greater_than_prerelease__should_match.jsonc
+++ b/test_cases/test_semver_greater_than_prerelease__should_match.jsonc
@@ -1,0 +1,45 @@
+{
+  // Given: A segment with GREATER_THAN condition checking version > "1.0.0-beta" using semver format
+  // When: An evaluation context with an identity that has version "1.0.0" (release vs pre-release)
+  // Then: The context should be considered part of the segment
+  "context": {
+    "environment": {
+      "key": "key",
+      "name": "Environment"
+    },
+    "identity": {
+      "identifier": "release_vs_beta_user",
+      "key": "key_release_vs_beta_user",
+      "traits": {
+        "app_version": "1.0.0"
+      }
+    },
+    "segments": {
+      "46": {
+        "key": "46",
+        "name": "segment_version_release_vs_beta",
+        "rules": [
+          {
+            "type": "ALL",
+            "conditions": [
+              {
+                "operator": "GREATER_THAN",
+                "property": "app_version",
+                "value": "1.0.0-beta:semver"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "result": {
+    "flags": {},
+    "segments": [
+      {
+        "key": "46",
+        "name": "segment_version_release_vs_beta"
+      }
+    ]
+  }
+}

--- a/test_cases/test_semver_greater_than_same_version__should_not_match.jsonc
+++ b/test_cases/test_semver_greater_than_same_version__should_not_match.jsonc
@@ -2,6 +2,7 @@
   // Given: A segment with GREATER_THAN condition checking version > "1.0.1" using semver format
   // When: An evaluation context with an identity that has version "1.0.1" (same version)
   // Then: The context should not be considered part of the segment
+  "$schema": "https://raw.githubusercontent.com/Flagsmith/engine-test-data/refs/tags/v2.0.0/schema.json",
   "context": {
     "environment": {
       "key": "key",

--- a/test_cases/test_semver_greater_than_same_version__should_not_match.jsonc
+++ b/test_cases/test_semver_greater_than_same_version__should_not_match.jsonc
@@ -1,0 +1,40 @@
+{
+  // Given: A segment with GREATER_THAN condition checking version > "1.0.1" using semver format
+  // When: An evaluation context with an identity that has version "1.0.1" (same version)
+  // Then: The context should not be considered part of the segment
+  "context": {
+    "environment": {
+      "key": "key",
+      "name": "Environment"
+    },
+    "identity": {
+      "identifier": "same_version_user",
+      "key": "key_same_version_user",
+      "traits": {
+        "app_version": "1.0.1"
+      }
+    },
+    "segments": {
+      "48": {
+        "key": "48",
+        "name": "segment_version_greater_same",
+        "rules": [
+          {
+            "type": "ALL",
+            "conditions": [
+              {
+                "operator": "GREATER_THAN",
+                "property": "app_version",
+                "value": "1.0.1:semver"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "result": {
+    "flags": {},
+    "segments": []
+  }
+}

--- a/test_cases/test_semver_less_than_inclusive_newer__should_not_match.jsonc
+++ b/test_cases/test_semver_less_than_inclusive_newer__should_not_match.jsonc
@@ -1,0 +1,40 @@
+{
+  // Given: A segment with LESS_THAN_INCLUSIVE condition checking version <= "1.0.0" using semver format
+  // When: An evaluation context with an identity that has version "1.0.1" (newer version)
+  // Then: The context should not be considered part of the segment
+  "context": {
+    "environment": {
+      "key": "key",
+      "name": "Environment"
+    },
+    "identity": {
+      "identifier": "newer_version_user",
+      "key": "key_newer_version_user",
+      "traits": {
+        "app_version": "1.0.1"
+      }
+    },
+    "segments": {
+      "59": {
+        "key": "59",
+        "name": "segment_version_lte_newer",
+        "rules": [
+          {
+            "type": "ALL",
+            "conditions": [
+              {
+                "operator": "LESS_THAN_INCLUSIVE",
+                "property": "app_version",
+                "value": "1.0.0:semver"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "result": {
+    "flags": {},
+    "segments": []
+  }
+}

--- a/test_cases/test_semver_less_than_inclusive_newer__should_not_match.jsonc
+++ b/test_cases/test_semver_less_than_inclusive_newer__should_not_match.jsonc
@@ -2,6 +2,7 @@
   // Given: A segment with LESS_THAN_INCLUSIVE condition checking version <= "1.0.0" using semver format
   // When: An evaluation context with an identity that has version "1.0.1" (newer version)
   // Then: The context should not be considered part of the segment
+  "$schema": "https://raw.githubusercontent.com/Flagsmith/engine-test-data/refs/tags/v2.0.0/schema.json",
   "context": {
     "environment": {
       "key": "key",

--- a/test_cases/test_semver_less_than_inclusive_older__should_match.jsonc
+++ b/test_cases/test_semver_less_than_inclusive_older__should_match.jsonc
@@ -2,6 +2,7 @@
   // Given: A segment with LESS_THAN_INCLUSIVE condition checking version <= "1.0.1" using semver format
   // When: An evaluation context with an identity that has version "1.0.0" (older version)
   // Then: The context should be considered part of the segment
+  "$schema": "https://raw.githubusercontent.com/Flagsmith/engine-test-data/refs/tags/v2.0.0/schema.json",
   "context": {
     "environment": {
       "key": "key",

--- a/test_cases/test_semver_less_than_inclusive_older__should_match.jsonc
+++ b/test_cases/test_semver_less_than_inclusive_older__should_match.jsonc
@@ -1,0 +1,45 @@
+{
+  // Given: A segment with LESS_THAN_INCLUSIVE condition checking version <= "1.0.1" using semver format
+  // When: An evaluation context with an identity that has version "1.0.0" (older version)
+  // Then: The context should be considered part of the segment
+  "context": {
+    "environment": {
+      "key": "key",
+      "name": "Environment"
+    },
+    "identity": {
+      "identifier": "older_version_user",
+      "key": "key_older_version_user",
+      "traits": {
+        "app_version": "1.0.0"
+      }
+    },
+    "segments": {
+      "57": {
+        "key": "57",
+        "name": "segment_version_lte_older",
+        "rules": [
+          {
+            "type": "ALL",
+            "conditions": [
+              {
+                "operator": "LESS_THAN_INCLUSIVE",
+                "property": "app_version",
+                "value": "1.0.1:semver"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "result": {
+    "flags": {},
+    "segments": [
+      {
+        "key": "57",
+        "name": "segment_version_lte_older"
+      }
+    ]
+  }
+}

--- a/test_cases/test_semver_less_than_inclusive_same__should_match.jsonc
+++ b/test_cases/test_semver_less_than_inclusive_same__should_match.jsonc
@@ -1,0 +1,45 @@
+{
+  // Given: A segment with LESS_THAN_INCLUSIVE condition checking version <= "1.0.0" using semver format
+  // When: An evaluation context with an identity that has version "1.0.0" (same version)
+  // Then: The context should be considered part of the segment
+  "context": {
+    "environment": {
+      "key": "key",
+      "name": "Environment"
+    },
+    "identity": {
+      "identifier": "same_version_user",
+      "key": "key_same_version_user",
+      "traits": {
+        "app_version": "1.0.0"
+      }
+    },
+    "segments": {
+      "58": {
+        "key": "58",
+        "name": "segment_version_lte_same",
+        "rules": [
+          {
+            "type": "ALL",
+            "conditions": [
+              {
+                "operator": "LESS_THAN_INCLUSIVE",
+                "property": "app_version",
+                "value": "1.0.0:semver"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "result": {
+    "flags": {},
+    "segments": [
+      {
+        "key": "58",
+        "name": "segment_version_lte_same"
+      }
+    ]
+  }
+}

--- a/test_cases/test_semver_less_than_inclusive_same__should_match.jsonc
+++ b/test_cases/test_semver_less_than_inclusive_same__should_match.jsonc
@@ -2,6 +2,7 @@
   // Given: A segment with LESS_THAN_INCLUSIVE condition checking version <= "1.0.0" using semver format
   // When: An evaluation context with an identity that has version "1.0.0" (same version)
   // Then: The context should be considered part of the segment
+  "$schema": "https://raw.githubusercontent.com/Flagsmith/engine-test-data/refs/tags/v2.0.0/schema.json",
   "context": {
     "environment": {
       "key": "key",

--- a/test_cases/test_semver_less_than_newer_version__should_match.jsonc
+++ b/test_cases/test_semver_less_than_newer_version__should_match.jsonc
@@ -2,6 +2,7 @@
   // Given: A segment with LESS_THAN condition checking version < "1.0.1" using semver format
   // When: An evaluation context with an identity that has version "1.0.0" (older version)
   // Then: The context should be considered part of the segment
+  "$schema": "https://raw.githubusercontent.com/Flagsmith/engine-test-data/refs/tags/v2.0.0/schema.json",
   "context": {
     "environment": {
       "key": "key",

--- a/test_cases/test_semver_less_than_newer_version__should_match.jsonc
+++ b/test_cases/test_semver_less_than_newer_version__should_match.jsonc
@@ -1,0 +1,45 @@
+{
+  // Given: A segment with LESS_THAN condition checking version < "1.0.1" using semver format
+  // When: An evaluation context with an identity that has version "1.0.0" (older version)
+  // Then: The context should be considered part of the segment
+  "context": {
+    "environment": {
+      "key": "key",
+      "name": "Environment"
+    },
+    "identity": {
+      "identifier": "older_version_user",
+      "key": "key_older_version_user",
+      "traits": {
+        "app_version": "1.0.0"
+      }
+    },
+    "segments": {
+      "50": {
+        "key": "50",
+        "name": "segment_version_less_than_newer",
+        "rules": [
+          {
+            "type": "ALL",
+            "conditions": [
+              {
+                "operator": "LESS_THAN",
+                "property": "app_version",
+                "value": "1.0.1:semver"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "result": {
+    "flags": {},
+    "segments": [
+      {
+        "key": "50",
+        "name": "segment_version_less_than_newer"
+      }
+    ]
+  }
+}

--- a/test_cases/test_semver_less_than_older_version__should_not_match.jsonc
+++ b/test_cases/test_semver_less_than_older_version__should_not_match.jsonc
@@ -2,6 +2,7 @@
   // Given: A segment with LESS_THAN condition checking version < "1.0.0" using semver format
   // When: An evaluation context with an identity that has version "1.0.1" (newer version)
   // Then: The context should not be considered part of the segment
+  "$schema": "https://raw.githubusercontent.com/Flagsmith/engine-test-data/refs/tags/v2.0.0/schema.json",
   "context": {
     "environment": {
       "key": "key",

--- a/test_cases/test_semver_less_than_older_version__should_not_match.jsonc
+++ b/test_cases/test_semver_less_than_older_version__should_not_match.jsonc
@@ -1,0 +1,40 @@
+{
+  // Given: A segment with LESS_THAN condition checking version < "1.0.0" using semver format
+  // When: An evaluation context with an identity that has version "1.0.1" (newer version)
+  // Then: The context should not be considered part of the segment
+  "context": {
+    "environment": {
+      "key": "key",
+      "name": "Environment"
+    },
+    "identity": {
+      "identifier": "newer_version_user",
+      "key": "key_newer_version_user",
+      "traits": {
+        "app_version": "1.0.1"
+      }
+    },
+    "segments": {
+      "52": {
+        "key": "52",
+        "name": "segment_version_less_than_older",
+        "rules": [
+          {
+            "type": "ALL",
+            "conditions": [
+              {
+                "operator": "LESS_THAN",
+                "property": "app_version",
+                "value": "1.0.0:semver"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "result": {
+    "flags": {},
+    "segments": []
+  }
+}

--- a/test_cases/test_semver_less_than_prerelease__should_match.jsonc
+++ b/test_cases/test_semver_less_than_prerelease__should_match.jsonc
@@ -1,0 +1,45 @@
+{
+  // Given: A segment with LESS_THAN condition checking version < "1.0.0-rc.3" using semver format
+  // When: An evaluation context with an identity that has version "1.0.0-rc.2" (pre-release comparison)
+  // Then: The context should be considered part of the segment
+  "context": {
+    "environment": {
+      "key": "key",
+      "name": "Environment"
+    },
+    "identity": {
+      "identifier": "prerelease_user",
+      "key": "key_prerelease_user",
+      "traits": {
+        "app_version": "1.0.0-rc.2"
+      }
+    },
+    "segments": {
+      "53": {
+        "key": "53",
+        "name": "segment_version_prerelease_comparison",
+        "rules": [
+          {
+            "type": "ALL",
+            "conditions": [
+              {
+                "operator": "LESS_THAN",
+                "property": "app_version",
+                "value": "1.0.0-rc.3:semver"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "result": {
+    "flags": {},
+    "segments": [
+      {
+        "key": "53",
+        "name": "segment_version_prerelease_comparison"
+      }
+    ]
+  }
+}

--- a/test_cases/test_semver_less_than_prerelease__should_match.jsonc
+++ b/test_cases/test_semver_less_than_prerelease__should_match.jsonc
@@ -2,6 +2,7 @@
   // Given: A segment with LESS_THAN condition checking version < "1.0.0-rc.3" using semver format
   // When: An evaluation context with an identity that has version "1.0.0-rc.2" (pre-release comparison)
   // Then: The context should be considered part of the segment
+  "$schema": "https://raw.githubusercontent.com/Flagsmith/engine-test-data/refs/tags/v2.0.0/schema.json",
   "context": {
     "environment": {
       "key": "key",

--- a/test_cases/test_semver_less_than_same_version__should_not_match.jsonc
+++ b/test_cases/test_semver_less_than_same_version__should_not_match.jsonc
@@ -1,0 +1,40 @@
+{
+  // Given: A segment with LESS_THAN condition checking version < "1.0.0" using semver format
+  // When: An evaluation context with an identity that has version "1.0.0" (same version)
+  // Then: The context should not be considered part of the segment
+  "context": {
+    "environment": {
+      "key": "key",
+      "name": "Environment"
+    },
+    "identity": {
+      "identifier": "same_version_user",
+      "key": "key_same_version_user",
+      "traits": {
+        "app_version": "1.0.0"
+      }
+    },
+    "segments": {
+      "51": {
+        "key": "51",
+        "name": "segment_version_less_than_same",
+        "rules": [
+          {
+            "type": "ALL",
+            "conditions": [
+              {
+                "operator": "LESS_THAN",
+                "property": "app_version",
+                "value": "1.0.0:semver"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "result": {
+    "flags": {},
+    "segments": []
+  }
+}

--- a/test_cases/test_semver_less_than_same_version__should_not_match.jsonc
+++ b/test_cases/test_semver_less_than_same_version__should_not_match.jsonc
@@ -2,6 +2,7 @@
   // Given: A segment with LESS_THAN condition checking version < "1.0.0" using semver format
   // When: An evaluation context with an identity that has version "1.0.0" (same version)
   // Then: The context should not be considered part of the segment
+  "$schema": "https://raw.githubusercontent.com/Flagsmith/engine-test-data/refs/tags/v2.0.0/schema.json",
   "context": {
     "environment": {
       "key": "key",

--- a/test_cases/test_semver_not_equal_different_version__should_match.jsonc
+++ b/test_cases/test_semver_not_equal_different_version__should_match.jsonc
@@ -2,6 +2,7 @@
   // Given: A segment with NOT_EQUAL condition checking version not equals "1.0.0" using semver format
   // When: An evaluation context with an identity that has version "1.0.1" (different version)
   // Then: The context should be considered part of the segment
+  "$schema": "https://raw.githubusercontent.com/Flagsmith/engine-test-data/refs/tags/v2.0.0/schema.json",
   "context": {
     "environment": {
       "key": "key",

--- a/test_cases/test_semver_not_equal_different_version__should_match.jsonc
+++ b/test_cases/test_semver_not_equal_different_version__should_match.jsonc
@@ -1,0 +1,45 @@
+{
+  // Given: A segment with NOT_EQUAL condition checking version not equals "1.0.0" using semver format
+  // When: An evaluation context with an identity that has version "1.0.1" (different version)
+  // Then: The context should be considered part of the segment
+  "context": {
+    "environment": {
+      "key": "key",
+      "name": "Environment"
+    },
+    "identity": {
+      "identifier": "different_version_user",
+      "key": "key_different_version_user",
+      "traits": {
+        "app_version": "1.0.1"
+      }
+    },
+    "segments": {
+      "45": {
+        "key": "45",
+        "name": "segment_version_not_equal_different",
+        "rules": [
+          {
+            "type": "ALL",
+            "conditions": [
+              {
+                "operator": "NOT_EQUAL",
+                "property": "app_version",
+                "value": "1.0.0:semver"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "result": {
+    "flags": {},
+    "segments": [
+      {
+        "key": "45",
+        "name": "segment_version_not_equal_different"
+      }
+    ]
+  }
+}

--- a/test_cases/test_semver_not_equal_same_version__should_not_match.jsonc
+++ b/test_cases/test_semver_not_equal_same_version__should_not_match.jsonc
@@ -2,6 +2,7 @@
   // Given: A segment with NOT_EQUAL condition checking version not equals "1.0.0" using semver format
   // When: An evaluation context with an identity that has version "1.0.0" (same version)
   // Then: The context should not be considered part of the segment
+  "$schema": "https://raw.githubusercontent.com/Flagsmith/engine-test-data/refs/tags/v2.0.0/schema.json",
   "context": {
     "environment": {
       "key": "key",

--- a/test_cases/test_semver_not_equal_same_version__should_not_match.jsonc
+++ b/test_cases/test_semver_not_equal_same_version__should_not_match.jsonc
@@ -1,0 +1,40 @@
+{
+  // Given: A segment with NOT_EQUAL condition checking version not equals "1.0.0" using semver format
+  // When: An evaluation context with an identity that has version "1.0.0" (same version)
+  // Then: The context should not be considered part of the segment
+  "context": {
+    "environment": {
+      "key": "key",
+      "name": "Environment"
+    },
+    "identity": {
+      "identifier": "same_version_user",
+      "key": "key_same_version_user",
+      "traits": {
+        "app_version": "1.0.0"
+      }
+    },
+    "segments": {
+      "44": {
+        "key": "44",
+        "name": "segment_version_not_equal_same",
+        "rules": [
+          {
+            "type": "ALL",
+            "conditions": [
+              {
+                "operator": "NOT_EQUAL",
+                "property": "app_version",
+                "value": "1.0.0:semver"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "result": {
+    "flags": {},
+    "segments": []
+  }
+}


### PR DESCRIPTION
Contributes to #13.

In this PR, we add test cases converted by Claude 4 from [Python engine's semver unit tests](https://github.com/Flagsmith/flagsmith-engine/blob/b4a47d7edced1024c38354434b8e5828795ff6d1/tests/unit/segments/test_segments_evaluator.py#L517-L560).