### PR TITLE
feat: Add in tests

### DIFF
--- a/test_cases/test_in_condition_array_matching_value__should_match.jsonc
+++ b/test_cases/test_in_condition_array_matching_value__should_match.jsonc
@@ -1,0 +1,50 @@
+{
+  // Given: A segment with an IN condition checking if status is in ["active", "premium", "vip"]
+  // When: An evaluation context with an identity that has status "premium" (matches one of the values)
+  // Then: The context should be considered part of the segment
+  "$schema": "https://raw.githubusercontent.com/Flagsmith/engine-test-data/refs/tags/v2.0.0/schema.json",
+  "context": {
+    "environment": {
+      "key": "key",
+      "name": "Environment"
+    },
+    "identity": {
+      "identifier": "premium_user",
+      "key": "key_premium_user",
+      "traits": {
+        "status": "premium"
+      }
+    },
+    "segments": {
+      "12": {
+        "key": "12",
+        "name": "segment_valued_customers",
+        "rules": [
+          {
+            "type": "ALL",
+            "conditions": [
+              {
+                "operator": "IN",
+                "property": "status",
+                "value": [
+                  "active",
+                  "premium",
+                  "vip"
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "result": {
+    "flags": {},
+    "segments": [
+      {
+        "key": "12",
+        "name": "segment_valued_customers"
+      }
+    ]
+  }
+}

--- a/test_cases/test_in_condition_array_numeric_value__should_match.jsonc
+++ b/test_cases/test_in_condition_array_numeric_value__should_match.jsonc
@@ -1,6 +1,6 @@
 {
-  // Given: A segment with IN condition using array format with actual array value (not string)
-  // When: An evaluation context with an identity that has numeric trait matching one of the array values
+  // Given: A segment with IN condition using an array of strings
+  // When: An evaluation context with an identity that has numeric trait (integer) matching one of the array values (strings)
   // Then: The context should be considered part of the segment
   "$schema": "https://raw.githubusercontent.com/Flagsmith/engine-test-data/refs/tags/v2.0.0/schema.json",
   "context": {

--- a/test_cases/test_in_condition_array_numeric_value__should_match.jsonc
+++ b/test_cases/test_in_condition_array_numeric_value__should_match.jsonc
@@ -1,0 +1,51 @@
+{
+  // Given: A segment with IN condition using array format with actual array value (not string)
+  // When: An evaluation context with an identity that has numeric trait matching one of the array values
+  // Then: The context should be considered part of the segment
+  "$schema": "https://raw.githubusercontent.com/Flagsmith/engine-test-data/refs/tags/v2.0.0/schema.json",
+  "context": {
+    "environment": {
+      "key": "key",
+      "name": "Environment"
+    },
+    "identity": {
+      "identifier": "array_value_user",
+      "key": "key_array_value_user",
+      "traits": {
+        "level": 1
+      }
+    },
+    "segments": {
+      "25": {
+        "key": "25",
+        "name": "segment_array_value_condition",
+        "rules": [
+          {
+            "type": "ALL",
+            "conditions": [
+              {
+                "operator": "IN",
+                "property": "level",
+                "value": [
+                  "1",
+                  "2",
+                  "3",
+                  "4"
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "result": {
+    "flags": {},
+    "segments": [
+      {
+        "key": "25",
+        "name": "segment_array_value_condition"
+      }
+    ]
+  }
+}

--- a/test_cases/test_in_condition_json_array_format__should_match.jsonc
+++ b/test_cases/test_in_condition_json_array_format__should_match.jsonc
@@ -1,0 +1,46 @@
+{
+  // Given: A segment with IN condition using JSON array format for string values
+  // When: An evaluation context with an identity that has status "premium" (matches one of ["active","premium","vip"])
+  // Then: The context should be considered part of the segment
+  "$schema": "https://raw.githubusercontent.com/Flagsmith/engine-test-data/refs/tags/v2.0.0/schema.json",
+  "context": {
+    "environment": {
+      "key": "key",
+      "name": "Environment"
+    },
+    "identity": {
+      "identifier": "json_array_user",
+      "key": "key_json_array_user",
+      "traits": {
+        "status": "premium"
+      }
+    },
+    "segments": {
+      "21": {
+        "key": "21",
+        "name": "segment_json_array_status",
+        "rules": [
+          {
+            "type": "ALL",
+            "conditions": [
+              {
+                "operator": "IN",
+                "property": "status",
+                "value": "[\"active\",\"premium\",\"vip\"]"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "result": {
+    "flags": {},
+    "segments": [
+      {
+        "key": "21",
+        "name": "segment_json_array_status"
+      }
+    ]
+  }
+}

--- a/test_cases/test_in_condition_json_literal__should_match.jsonc
+++ b/test_cases/test_in_condition_json_literal__should_match.jsonc
@@ -1,0 +1,46 @@
+{
+  // Given: A segment with IN condition using a JSON literal string (not an array)
+  // When: An evaluation context with an identity that has a trait matching the exact JSON literal
+  // Then: The context should be considered part of the segment
+  "$schema": "https://raw.githubusercontent.com/Flagsmith/engine-test-data/refs/tags/v2.0.0/schema.json",
+  "context": {
+    "environment": {
+      "key": "key",
+      "name": "Environment"
+    },
+    "identity": {
+      "identifier": "json_literal_user",
+      "key": "key_json_literal_user",
+      "traits": {
+        "description": "\"I am a valid JSON literal but not a list\""
+      }
+    },
+    "segments": {
+      "26": {
+        "key": "26",
+        "name": "segment_json_literal_condition",
+        "rules": [
+          {
+            "type": "ALL",
+            "conditions": [
+              {
+                "operator": "IN",
+                "property": "description",
+                "value": "\"I am a valid JSON literal but not a list\""
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "result": {
+    "flags": {},
+    "segments": [
+      {
+        "key": "26",
+        "name": "segment_json_literal_condition"
+      }
+    ]
+  }
+}

--- a/test_cases/test_in_condition_none_trait__should_not_match.jsonc
+++ b/test_cases/test_in_condition_none_trait__should_not_match.jsonc
@@ -1,0 +1,41 @@
+{
+  // Given: A segment with IN condition using comma-separated string values and None trait
+  // When: An evaluation context with an identity that has a None trait value
+  // Then: The context should not be considered part of the segment since None doesn't match string values
+  "$schema": "https://raw.githubusercontent.com/Flagsmith/engine-test-data/refs/tags/v2.0.0/schema.json",
+  "context": {
+    "environment": {
+      "key": "key",
+      "name": "Environment"
+    },
+    "identity": {
+      "identifier": "none_trait_user",
+      "key": "key_none_trait_user",
+      "traits": {
+        "status": null
+      }
+    },
+    "segments": {
+      "24": {
+        "key": "24",
+        "name": "segment_string_values_with_none_trait",
+        "rules": [
+          {
+            "type": "ALL",
+            "conditions": [
+              {
+                "operator": "IN",
+                "property": "status",
+                "value": "foo,None,null,bar"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "result": {
+    "flags": {},
+    "segments": []
+  }
+}

--- a/test_cases/test_in_condition_numeric_comma_separated__should_match.jsonc
+++ b/test_cases/test_in_condition_numeric_comma_separated__should_match.jsonc
@@ -1,0 +1,46 @@
+{
+  // Given: A segment with IN condition using comma-separated numeric values
+  // When: An evaluation context with an identity that has level = 2 (matches one of "1,2,3,4")
+  // Then: The context should be considered part of the segment
+  "$schema": "https://raw.githubusercontent.com/Flagsmith/engine-test-data/refs/tags/v2.0.0/schema.json",
+  "context": {
+    "environment": {
+      "key": "key",
+      "name": "Environment"
+    },
+    "identity": {
+      "identifier": "level_user",
+      "key": "key_level_user",
+      "traits": {
+        "level": 2
+      }
+    },
+    "segments": {
+      "22": {
+        "key": "22",
+        "name": "segment_basic_levels",
+        "rules": [
+          {
+            "type": "ALL",
+            "conditions": [
+              {
+                "operator": "IN",
+                "property": "level",
+                "value": "1,2,3,4"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "result": {
+    "flags": {},
+    "segments": [
+      {
+        "key": "22",
+        "name": "segment_basic_levels"
+      }
+    ]
+  }
+}

--- a/test_cases/test_in_condition_partial_comma_separated__should_not_match.jsonc
+++ b/test_cases/test_in_condition_partial_comma_separated__should_not_match.jsonc
@@ -1,0 +1,41 @@
+{
+  // Given: A segment with an IN condition checking using comma-separated string values
+  // When: An evaluation context with an identity that has status "prem" (part of "premium" but not exact match)
+  // Then: The context should not be considered part of the segment
+  "$schema": "https://raw.githubusercontent.com/Flagsmith/engine-test-data/refs/tags/v2.0.0/schema.json",
+  "context": {
+    "environment": {
+      "key": "key",
+      "name": "Environment"
+    },
+    "identity": {
+      "identifier": "premium_user",
+      "key": "key_premium_user",
+      "traits": {
+        "status": "prem"
+      }
+    },
+    "segments": {
+      "12": {
+        "key": "12",
+        "name": "segment_valued_customers",
+        "rules": [
+          {
+            "type": "ALL",
+            "conditions": [
+              {
+                "operator": "IN",
+                "property": "status",
+                "value": "active,premium,vip"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "result": {
+    "flags": {},
+    "segments": []
+  }
+}


### PR DESCRIPTION
Closes #16.
Contributes to #13.

Once again, this is Claude-generated from the Python unit tests, with a number of minor manual edits. The improved example values and segment names are courtesy of Claude.