### PR TITLE
fix: Remove trailing comma in multivariate segment override test

### DIFF
--- a/test_cases/test_multivariate__segment_override__expected_allocation.jsonc
+++ b/test_cases/test_multivariate__segment_override__expected_allocation.jsonc
@@ -11,7 +11,7 @@
     },
     "identity": {
       "identifier": "user-123",
-      "key": "8AYnz4q3KEfT5DFtnramnP_user-123",
+      "key": "8AYnz4q3KEfT5DFtnramnP_user-123"
     },
     "features": {
       "mv_feature": {


### PR DESCRIPTION
The test file had an invalid trailing comma after the identity key field on line 14, which caused JSON parsing errors in Rust's serde_json parser.

This commit removes the trailing comma to make the JSON valid.