### PR TITLE
feat(Mappers): Add mapper test cases

### DIFF
--- a/mapper_test_cases/test_mapper__complete_environment__expected_context.jsonc
+++ b/mapper_test_cases/test_mapper__complete_environment__expected_context.jsonc
@@ -1,0 +1,286 @@
+{
+  "environment_document": {
+    "api_key": "B62qaMZNwfiqT76p38ggrQ",
+    "name": "Test environment",
+    "project": {
+      "name": "Test project",
+      "organisation": {
+        "feature_analytics": false,
+        "name": "Test Org",
+        "id": 1,
+        "persist_trait_data": true,
+        "stop_serving_flags": false
+      },
+      "id": 1,
+      "hide_disabled_flags": false,
+      "segments": [
+        {
+          "id": 1,
+          "name": "Test segment",
+          "rules": [
+            {
+              "type": "ALL",
+              "rules": [
+                {
+                  "type": "ALL",
+                  "rules": [],
+                  "conditions": [
+                    {
+                      "operator": "EQUAL",
+                      "property_": "foo",
+                      "value": "bar"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "segment_overrides": [],
+    "id": 1,
+    "feature_states": [
+      {
+        "feature_state_value": "some-value",
+        "id": 1,
+        "featurestate_uuid": "00000000-0000-0000-0000-000000000000",
+        "feature": {
+          "name": "some_feature",
+          "type": "STANDARD",
+          "id": 1
+        },
+        "segment_id": null,
+        "enabled": true,
+        "multivariate_feature_state_values": []
+      },
+      {
+        "feature_state_value": "default_value",
+        "django_id": 2,
+        "featurestate_uuid": "11111111-1111-1111-1111-111111111111",
+        "feature": {
+          "name": "mv_feature_with_ids",
+          "type": "MULTIVARIATE",
+          "id": 2
+        },
+        "segment_id": null,
+        "enabled": true,
+        "multivariate_feature_state_values": [
+          {
+            "id": 100,
+            "multivariate_feature_option": {
+              "id": 10,
+              "value": "variant_a"
+            },
+            "mv_fs_value_uuid": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "percentage_allocation": 30.0
+          },
+          {
+            "id": 200,
+            "multivariate_feature_option": {
+              "id": 20,
+              "value": "variant_b"
+            },
+            "mv_fs_value_uuid": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+            "percentage_allocation": 70.0
+          }
+        ]
+      },
+      {
+        "feature_state_value": "fallback_value",
+        "django_id": 3,
+        "featurestate_uuid": "22222222-2222-2222-2222-222222222222",
+        "feature": {
+          "name": "mv_feature_without_ids",
+          "type": "MULTIVARIATE",
+          "id": 3
+        },
+        "segment_id": null,
+        "enabled": false,
+        "multivariate_feature_state_values": [
+          {
+            "multivariate_feature_option": {
+              "id": 40,
+              "value": "option_y"
+            },
+            "mv_fs_value_uuid": "yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy",
+            "percentage_allocation": 50.0
+          },
+          {
+            "multivariate_feature_option": {
+              "id": 30,
+              "value": "option_x"
+            },
+            "mv_fs_value_uuid": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+            "percentage_allocation": 25.0
+          },
+          {
+            "multivariate_feature_option": {
+              "id": 50,
+              "value": "option_z"
+            },
+            "mv_fs_value_uuid": "zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz",
+            "percentage_allocation": 25.0
+          }
+        ]
+      }
+    ],
+    "identity_overrides": [
+      {
+        "identifier": "overridden-id",
+        "identity_uuid": "0f21cde8-63c5-4e50-baca-87897fa6cd01",
+        "created_date": "2019-08-27T14:53:45.698555Z",
+        "updated_at": "2023-07-14 16:12:00.000000",
+        "environment_api_key": "B62qaMZNwfiqT76p38ggrQ",
+        "identity_features": [
+          {
+            "id": 1,
+            "feature": {
+              "id": 1,
+              "name": "some_feature",
+              "type": "STANDARD"
+            },
+            "featurestate_uuid": "1bddb9a5-7e59-42c6-9be9-625fa369749f",
+            "feature_state_value": "some-overridden-value",
+            "enabled": false,
+            "environment": 1,
+            "identity": null,
+            "feature_segment": null
+          }
+        ]
+      }
+    ]
+  },
+  "expected_evaluation_context": {
+    "environment": {
+      "key": "B62qaMZNwfiqT76p38ggrQ",
+      "name": "Test environment"
+    },
+    "identity": null,
+    "segments": {
+      "0": {
+        "key": "1",
+        "name": "Test segment",
+        "rules": [
+          {
+            "type": "ALL",
+            "conditions": [],
+            "rules": [
+              {
+                "type": "ALL",
+                "conditions": [
+                  {
+                    "property": "foo",
+                    "operator": "EQUAL",
+                    "value": "bar"
+                  }
+                ],
+                "rules": []
+              }
+            ]
+          }
+        ],
+        "overrides": [],
+        "metadata": {
+          "source": "api",
+          "id": 1
+        }
+      },
+      "1011e8db6ebc6fc7d7ad32c3c49e6b2b79ea110abfd8bb9eaa0a228e1b924a74": {
+        "key": "",
+        "name": "identity_overrides",
+        "rules": [
+          {
+            "type": "ALL",
+            "conditions": [
+              {
+                "property": "$.identity.identifier",
+                "operator": "IN",
+                "value": ["overridden-id"]
+              }
+            ],
+            "rules": null
+          }
+        ],
+        "overrides": [
+          {
+            "key": "",
+            "name": "some_feature",
+            "enabled": false,
+            "value": "some-overridden-value",
+            "priority": "-INF",
+            "variants": null,
+            "metadata": {
+              "id": 1
+            }
+          }
+        ],
+        "metadata": {
+          "source": "identity_override"
+        }
+      }
+    },
+    "features": {
+      "some_feature": {
+        "key": "00000000-0000-0000-0000-000000000000",
+        "name": "some_feature",
+        "enabled": true,
+        "value": "some-value",
+        "priority": null,
+        "variants": [],
+        "metadata": {
+          "id": 1
+        }
+      },
+      "mv_feature_with_ids": {
+        "key": "2",
+        "name": "mv_feature_with_ids",
+        "enabled": true,
+        "value": "default_value",
+        "priority": null,
+        "variants": [
+          {
+            "value": "variant_a",
+            "weight": 30.0,
+            "priority": 100
+          },
+          {
+            "value": "variant_b",
+            "weight": 70.0,
+            "priority": 200
+          }
+        ],
+        "metadata": {
+          "id": 2
+        }
+      },
+      "mv_feature_without_ids": {
+        "key": "3",
+        "name": "mv_feature_without_ids",
+        "enabled": false,
+        "value": "fallback_value",
+        "priority": null,
+        "variants": [
+          {
+            "value": "option_y",
+            "weight": 50.0,
+            "priority": 1
+          },
+          {
+            "value": "option_x",
+            "weight": 25.0,
+            "priority": 0
+          },
+          {
+            "value": "option_z",
+            "weight": 25.0,
+            "priority": 2
+          }
+        ],
+        "metadata": {
+          "id": 3
+        }
+      }
+    }
+  }
+}

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,11 @@
 # Engine Test Data
 
+> [!NOTE]
+> Test case files may contain descriptions in JSON5-compliant comments. Test implementations should be ready to parse JSON5.
+
 E2E tests for all Flagsmith Engine implementations.
+
+## Engine Evaluation Tests
 
 Test cases ported from v1 are named in the pattern of `test_case/test_{context_value}__{matching_segments}.json`, where:
  - `{context_value}` is the main context value matched in the case — usually, `$.identity.identifier`.
@@ -8,4 +13,13 @@ Test cases ported from v1 are named in the pattern of `test_case/test_{context_v
 
 Single test case contents are described with [schema.json](./schema.json) JSONSchema.
 
-A test case file may contain a test description in the form of a JSON5-compliant comment in the beginning of the file. Test implementations should be ready to parse JSON5.
+## Mapper Tests
+
+> [!WARNING]
+> Mapper tests exist only to support safe deprecation of the environment document. These tests validate the conversion layer between the legacy environment document format and the evaluation context.
+
+Mapper test cases validate the conversion from environment documents to evaluation contexts. Test files are located in `mapper_test_cases/` and follow the naming pattern `test_mapper__{description}.jsonc`.
+
+Each mapper test case contains:
+- `environment_document`: The input environment document
+- `expected_evaluation_context`: The expected output evaluation context


### PR DESCRIPTION
Mapper test cases validate conversion from environment documents to evaluation contexts.

## Changes
- [x] Add `mapper_test_cases/` directory with test data
- [x] Add comprehensive mapper test case covering segments, features, identity overrides, and multivariate features
- [x] Update readme with mapper tests documentation

> [!WARNING]
> Mapper tests exist only to support safe deprecation of the environment document.

Review effort: 2/5