### PR TITLE
feat: Add IN condition bracketed-invalid-JSON CSV fallback test

### DIFF
--- a/test_cases/test_in_condition_bracketed_invalid_json__falls_back_to_csv__should_match.jsonc
+++ b/test_cases/test_in_condition_bracketed_invalid_json__falls_back_to_csv__should_match.jsonc
@@ -1,0 +1,46 @@
+{
+  // Given: An IN condition whose string value starts with "[" and ends with "]"
+  //        but isn't actually valid JSON.
+  // When: An evaluation context with status = "[foo" (one of the comma-split tokens).
+  // Then: The engine should fall back to a comma-split and match.
+  "$schema": "https://raw.githubusercontent.com/Flagsmith/engine-test-data/refs/tags/v2.0.0/schema.json",
+  "context": {
+    "environment": {
+      "key": "key",
+      "name": "Environment"
+    },
+    "identity": {
+      "identifier": "csv_fallback_user",
+      "key": "key_csv_fallback_user",
+      "traits": {
+        "status": "[foo"
+      }
+    },
+    "segments": {
+      "99": {
+        "key": "99",
+        "name": "segment_csv_fallback",
+        "rules": [
+          {
+            "type": "ALL",
+            "conditions": [
+              {
+                "operator": "IN",
+                "property": "status",
+                "value": "[foo,bar]"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "result": {
+    "flags": {},
+    "segments": [
+      {
+        "name": "segment_csv_fallback"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Contributes to https://github.com/Flagsmith/flagsmith-python-client/issues/198

- Adds a test case covering an IN segment condition whose string value looks list-shaped (`"[foo,bar]"`) but isn't valid JSON.
- Engine implementations should fall back to splitting on commas, so the trait value `"[foo"` matches one of the CSV tokens.