### PR TITLE
feat: added tests supporting sub nested rules in segment

### DIFF
--- a/test_cases/test_any_rule_with_nested_all_groups__no_group_matches__should_not_match.jsonc
+++ b/test_cases/test_any_rule_with_nested_all_groups__no_group_matches__should_not_match.jsonc
@@ -1,5 +1,5 @@
 {
-  // Given: A segment with an ANY rule containing two ALL sub-rule groups
+  // Given: A segment with a top-level ANY rule containing ALL sub-rule groups
   // When: Identity traits match neither group (wrong user_id for Production)
   // Then: The segment should not match
   "$schema": "https://raw.githubusercontent.com/Flagsmith/engine-test-data/refs/tags/v2.0.0/schema.json",
@@ -21,40 +21,35 @@
         "name": "user_per_env",
         "rules": [
           {
-            "type": "ALL",
+            "type": "ANY",
             "rules": [
               {
-                "type": "ANY",
-                "rules": [
+                "type": "ALL",
+                "conditions": [
                   {
-                    "type": "ALL",
-                    "conditions": [
-                      {
-                        "operator": "EQUAL",
-                        "property": "$.environment.name",
-                        "value": "Production"
-                      },
-                      {
-                        "operator": "EQUAL",
-                        "property": "user_id",
-                        "value": "123"
-                      }
-                    ]
+                    "operator": "EQUAL",
+                    "property": "$.environment.name",
+                    "value": "Production"
                   },
                   {
-                    "type": "ALL",
-                    "conditions": [
-                      {
-                        "operator": "EQUAL",
-                        "property": "$.environment.name",
-                        "value": "QA"
-                      },
-                      {
-                        "operator": "EQUAL",
-                        "property": "user_id",
-                        "value": "456"
-                      }
-                    ]
+                    "operator": "EQUAL",
+                    "property": "user_id",
+                    "value": "123"
+                  }
+                ]
+              },
+              {
+                "type": "ALL",
+                "conditions": [
+                  {
+                    "operator": "EQUAL",
+                    "property": "$.environment.name",
+                    "value": "QA"
+                  },
+                  {
+                    "operator": "EQUAL",
+                    "property": "user_id",
+                    "value": "456"
                   }
                 ]
               }

--- a/test_cases/test_any_rule_with_nested_all_groups__no_group_matches__should_not_match.jsonc
+++ b/test_cases/test_any_rule_with_nested_all_groups__no_group_matches__should_not_match.jsonc
@@ -1,0 +1,94 @@
+{
+  // Given: A segment with an ANY rule containing two ALL sub-rule groups
+  // When: Identity traits match neither group (wrong user_id for Production)
+  // Then: The segment should not match
+  "$schema": "https://raw.githubusercontent.com/Flagsmith/engine-test-data/refs/tags/v2.0.0/schema.json",
+  "context": {
+    "environment": {
+      "key": "key",
+      "name": "Production"
+    },
+    "identity": {
+      "identifier": "user_2",
+      "key": "key_user_2",
+      "traits": {
+        "user_id": "999"
+      }
+    },
+    "segments": {
+      "100": {
+        "key": "100",
+        "name": "user_per_env",
+        "rules": [
+          {
+            "type": "ALL",
+            "rules": [
+              {
+                "type": "ANY",
+                "rules": [
+                  {
+                    "type": "ALL",
+                    "conditions": [
+                      {
+                        "operator": "EQUAL",
+                        "property": "$.environment.name",
+                        "value": "Production"
+                      },
+                      {
+                        "operator": "EQUAL",
+                        "property": "user_id",
+                        "value": "123"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "ALL",
+                    "conditions": [
+                      {
+                        "operator": "EQUAL",
+                        "property": "$.environment.name",
+                        "value": "QA"
+                      },
+                      {
+                        "operator": "EQUAL",
+                        "property": "user_id",
+                        "value": "456"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "overrides": [
+          {
+            "enabled": true,
+            "key": "1",
+            "name": "test_feature",
+            "value": "overridden"
+          }
+        ]
+      }
+    },
+    "features": {
+      "test_feature": {
+        "enabled": false,
+        "key": "1",
+        "name": "test_feature",
+        "value": "default"
+      }
+    }
+  },
+  "result": {
+    "flags": {
+      "test_feature": {
+        "enabled": false,
+        "name": "test_feature",
+        "value": "default",
+        "reason": "DEFAULT"
+      }
+    },
+    "segments": []
+  }
+}

--- a/test_cases/test_any_rule_with_nested_all_groups__one_group_matches__should_match.jsonc
+++ b/test_cases/test_any_rule_with_nested_all_groups__one_group_matches__should_match.jsonc
@@ -1,5 +1,5 @@
 {
-  // Given: A segment with an ANY rule containing two ALL sub-rule groups
+  // Given: A segment with a top-level ANY rule containing ALL sub-rule groups
   // When: Identity traits match one group (Production + user 123) but not the other
   // Then: The segment should match (ANY = OR between groups)
   "$schema": "https://raw.githubusercontent.com/Flagsmith/engine-test-data/refs/tags/v2.0.0/schema.json",
@@ -21,40 +21,35 @@
         "name": "user_per_env",
         "rules": [
           {
-            "type": "ALL",
+            "type": "ANY",
             "rules": [
               {
-                "type": "ANY",
-                "rules": [
+                "type": "ALL",
+                "conditions": [
                   {
-                    "type": "ALL",
-                    "conditions": [
-                      {
-                        "operator": "EQUAL",
-                        "property": "$.environment.name",
-                        "value": "Production"
-                      },
-                      {
-                        "operator": "EQUAL",
-                        "property": "user_id",
-                        "value": "123"
-                      }
-                    ]
+                    "operator": "EQUAL",
+                    "property": "$.environment.name",
+                    "value": "Production"
                   },
                   {
-                    "type": "ALL",
-                    "conditions": [
-                      {
-                        "operator": "EQUAL",
-                        "property": "$.environment.name",
-                        "value": "QA"
-                      },
-                      {
-                        "operator": "EQUAL",
-                        "property": "user_id",
-                        "value": "456"
-                      }
-                    ]
+                    "operator": "EQUAL",
+                    "property": "user_id",
+                    "value": "123"
+                  }
+                ]
+              },
+              {
+                "type": "ALL",
+                "conditions": [
+                  {
+                    "operator": "EQUAL",
+                    "property": "$.environment.name",
+                    "value": "QA"
+                  },
+                  {
+                    "operator": "EQUAL",
+                    "property": "user_id",
+                    "value": "456"
                   }
                 ]
               }

--- a/test_cases/test_any_rule_with_nested_all_groups__one_group_matches__should_match.jsonc
+++ b/test_cases/test_any_rule_with_nested_all_groups__one_group_matches__should_match.jsonc
@@ -1,0 +1,98 @@
+{
+  // Given: A segment with an ANY rule containing two ALL sub-rule groups
+  // When: Identity traits match one group (Production + user 123) but not the other
+  // Then: The segment should match (ANY = OR between groups)
+  "$schema": "https://raw.githubusercontent.com/Flagsmith/engine-test-data/refs/tags/v2.0.0/schema.json",
+  "context": {
+    "environment": {
+      "key": "key",
+      "name": "Production"
+    },
+    "identity": {
+      "identifier": "user_1",
+      "key": "key_user_1",
+      "traits": {
+        "user_id": "123"
+      }
+    },
+    "segments": {
+      "100": {
+        "key": "100",
+        "name": "user_per_env",
+        "rules": [
+          {
+            "type": "ALL",
+            "rules": [
+              {
+                "type": "ANY",
+                "rules": [
+                  {
+                    "type": "ALL",
+                    "conditions": [
+                      {
+                        "operator": "EQUAL",
+                        "property": "$.environment.name",
+                        "value": "Production"
+                      },
+                      {
+                        "operator": "EQUAL",
+                        "property": "user_id",
+                        "value": "123"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "ALL",
+                    "conditions": [
+                      {
+                        "operator": "EQUAL",
+                        "property": "$.environment.name",
+                        "value": "QA"
+                      },
+                      {
+                        "operator": "EQUAL",
+                        "property": "user_id",
+                        "value": "456"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "overrides": [
+          {
+            "enabled": true,
+            "key": "1",
+            "name": "test_feature",
+            "value": "overridden"
+          }
+        ]
+      }
+    },
+    "features": {
+      "test_feature": {
+        "enabled": false,
+        "key": "1",
+        "name": "test_feature",
+        "value": "default"
+      }
+    }
+  },
+  "result": {
+    "flags": {
+      "test_feature": {
+        "enabled": true,
+        "name": "test_feature",
+        "value": "overridden",
+        "reason": "TARGETING_MATCH; segment=user_per_env"
+      }
+    },
+    "segments": [
+      {
+        "name": "user_per_env"
+      }
+    ]
+  }
+}

--- a/test_cases/test_none_rule_with_nested_all_groups__match__should_exclude.jsonc
+++ b/test_cases/test_none_rule_with_nested_all_groups__match__should_exclude.jsonc
@@ -1,6 +1,6 @@
 {
-  // Given: A segment with a NONE rule containing an ALL sub-rule group
-  // When: Identity traits match the ALL group (is_bot = true)
+  // Given: A segment with a top-level NONE rule containing an ALL sub-rule group
+  // When: Identity traits match the ALL group (is_bot = true AND tier = free)
   // Then: The segment should not match (NONE excludes matching groups)
   "$schema": "https://raw.githubusercontent.com/Flagsmith/engine-test-data/refs/tags/v2.0.0/schema.json",
   "context": {
@@ -22,25 +22,20 @@
         "name": "exclude_bots",
         "rules": [
           {
-            "type": "ALL",
+            "type": "NONE",
             "rules": [
               {
-                "type": "NONE",
-                "rules": [
+                "type": "ALL",
+                "conditions": [
                   {
-                    "type": "ALL",
-                    "conditions": [
-                      {
-                        "operator": "EQUAL",
-                        "property": "is_bot",
-                        "value": "true"
-                      },
-                      {
-                        "operator": "EQUAL",
-                        "property": "tier",
-                        "value": "free"
-                      }
-                    ]
+                    "operator": "EQUAL",
+                    "property": "is_bot",
+                    "value": "true"
+                  },
+                  {
+                    "operator": "EQUAL",
+                    "property": "tier",
+                    "value": "free"
                   }
                 ]
               }

--- a/test_cases/test_none_rule_with_nested_all_groups__match__should_exclude.jsonc
+++ b/test_cases/test_none_rule_with_nested_all_groups__match__should_exclude.jsonc
@@ -1,0 +1,80 @@
+{
+  // Given: A segment with a NONE rule containing an ALL sub-rule group
+  // When: Identity traits match the ALL group (is_bot = true)
+  // Then: The segment should not match (NONE excludes matching groups)
+  "$schema": "https://raw.githubusercontent.com/Flagsmith/engine-test-data/refs/tags/v2.0.0/schema.json",
+  "context": {
+    "environment": {
+      "key": "key",
+      "name": "Production"
+    },
+    "identity": {
+      "identifier": "bot_user",
+      "key": "key_bot_user",
+      "traits": {
+        "is_bot": "true",
+        "tier": "free"
+      }
+    },
+    "segments": {
+      "200": {
+        "key": "200",
+        "name": "exclude_bots",
+        "rules": [
+          {
+            "type": "ALL",
+            "rules": [
+              {
+                "type": "NONE",
+                "rules": [
+                  {
+                    "type": "ALL",
+                    "conditions": [
+                      {
+                        "operator": "EQUAL",
+                        "property": "is_bot",
+                        "value": "true"
+                      },
+                      {
+                        "operator": "EQUAL",
+                        "property": "tier",
+                        "value": "free"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "overrides": [
+          {
+            "enabled": true,
+            "key": "1",
+            "name": "test_feature",
+            "value": "overridden"
+          }
+        ]
+      }
+    },
+    "features": {
+      "test_feature": {
+        "enabled": false,
+        "key": "1",
+        "name": "test_feature",
+        "value": "default"
+      }
+    }
+  },
+  "result": {
+    "flags": {
+      "test_feature": {
+        "enabled": false,
+        "name": "test_feature",
+        "value": "default",
+        "reason": "DEFAULT"
+      }
+    },
+    "segments": []
+  }
+}


### PR DESCRIPTION
Tests covering the addition of a new level of nesting in segment rules. The goal is to be able to support the following use-case:
`(environment_name=env_1 and some_trait=foo) or (environment_name=env_2 and some_trait=bar) or (environment_name=env_3 and some_trait=baz)`

- ANY + nested ALL, one group matches → segment matches (the core use case)
- ANY + nested ALL, no group matches → segment doesn't match
- NONE + nested ALL, group matches → segment excluded