### PR TITLE
feat: add variant to every flag result

### DIFF
--- a/test_cases/test_042b3a46-4575-419a-8a2f-62baa3226668__default.json
+++ b/test_cases/test_042b3a46-4575-419a-8a2f-62baa3226668__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": "control"
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_0cfd0d72-4de4-4ed7-9cfb-d80dc3dacead__default.json
+++ b/test_cases/test_0cfd0d72-4de4-4ed7-9cfb-d80dc3dacead__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "SPLIT; weight=30",
-        "value": "baz"
+        "value": "baz",
+        "variant": null
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_0d0eb3b4-aab5-4a2e-b82a-47e84c57c64d__default.json
+++ b/test_cases/test_0d0eb3b4-aab5-4a2e-b82a-47e84c57c64d__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "SPLIT; weight=30",
-        "value": "baz"
+        "value": "baz",
+        "variant": null
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_11586d45-02f1-48ac-b640-741447251909__default.json
+++ b/test_cases/test_11586d45-02f1-48ac-b640-741447251909__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "SPLIT; weight=30",
-        "value": "bar"
+        "value": "bar",
+        "variant": null
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_15ef44aa-34b5-4366-a201-c80e33d9f169__default.json
+++ b/test_cases/test_15ef44aa-34b5-4366-a201-c80e33d9f169__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "SPLIT; weight=30",
-        "value": "baz"
+        "value": "baz",
+        "variant": null
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_170effbe-4388-49a5-9872-700688b628b9__default.json
+++ b/test_cases/test_170effbe-4388-49a5-9872-700688b628b9__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": "control"
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_18edb157-34cc-4896-aa35-76a7ee68fe68__default.json
+++ b/test_cases/test_18edb157-34cc-4896-aa35-76a7ee68fe68__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "SPLIT; weight=30",
-        "value": "bar"
+        "value": "bar",
+        "variant": null
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_1969664e-a236-46e7-91af-84dca50a313b__default.json
+++ b/test_cases/test_1969664e-a236-46e7-91af-84dca50a313b__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": "control"
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_1b33fc3f-3c0e-480c-acce-1937779c743b__default.json
+++ b/test_cases/test_1b33fc3f-3c0e-480c-acce-1937779c743b__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "SPLIT; weight=30",
-        "value": "bar"
+        "value": "bar",
+        "variant": null
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_1bde8445-ca19-4bda-a9d5-3543a800fc0f__context_values.json
+++ b/test_cases/test_1bde8445-ca19-4bda-a9d5-3543a800fc0f__context_values.json
@@ -283,35 +283,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "SPLIT; weight=30",
-        "value": "baz"
+        "value": "baz",
+        "variant": null
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "TARGETING_MATCH; segment=context_values",
-        "value": "context_values"
+        "value": "context_values",
+        "variant": null
       }
     },
     "segments": [

--- a/test_cases/test_1ccf1600-ca87-47f0-8cd9-225f9f8389a6__default.json
+++ b/test_cases/test_1ccf1600-ca87-47f0-8cd9-225f9f8389a6__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "SPLIT; weight=30",
-        "value": "baz"
+        "value": "baz",
+        "variant": null
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_20e6204b-e396-4d4b-a861-bb136c276ac2__default.json
+++ b/test_cases/test_20e6204b-e396-4d4b-a861-bb136c276ac2__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": "control"
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_2269ea5c-4509-4b7e-acd8-1f7763837464__default.json
+++ b/test_cases/test_2269ea5c-4509-4b7e-acd8-1f7763837464__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": "control"
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_233de9e2-df63-49ca-9f5a-dca000db568d__default.json
+++ b/test_cases/test_233de9e2-df63-49ca-9f5a-dca000db568d__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": "control"
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_23edd289-5188-4af0-b0bf-64c42f73f2f4__default.json
+++ b/test_cases/test_23edd289-5188-4af0-b0bf-64c42f73f2f4__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "SPLIT; weight=30",
-        "value": "bar"
+        "value": "bar",
+        "variant": null
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_2448af3b-bf5c-493b-9bce-13be5d6e697a__default.json
+++ b/test_cases/test_2448af3b-bf5c-493b-9bce-13be5d6e697a__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "SPLIT; weight=30",
-        "value": "bar"
+        "value": "bar",
+        "variant": null
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_269c4565-50fa-4e4d-9d1b-e349545c9b1b__default.json
+++ b/test_cases/test_269c4565-50fa-4e4d-9d1b-e349545c9b1b__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "SPLIT; weight=30",
-        "value": "bar"
+        "value": "bar",
+        "variant": null
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_28501e08-e978-4336-9ddd-d90d87983ab3__default.json
+++ b/test_cases/test_28501e08-e978-4336-9ddd-d90d87983ab3__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "SPLIT; weight=30",
-        "value": "bar"
+        "value": "bar",
+        "variant": null
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_29f66219-8344-4df4-a294-92efb44db0c5__default.json
+++ b/test_cases/test_29f66219-8344-4df4-a294-92efb44db0c5__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": "control"
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_2af98d3d-be2f-4bee-b7ae-83c53e1b2811__default.json
+++ b/test_cases/test_2af98d3d-be2f-4bee-b7ae-83c53e1b2811__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "SPLIT; weight=30",
-        "value": "baz"
+        "value": "baz",
+        "variant": null
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_2b051612-8a49-4e04-9500-5daedb8fec88__default.json
+++ b/test_cases/test_2b051612-8a49-4e04-9500-5daedb8fec88__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "SPLIT; weight=30",
-        "value": "bar"
+        "value": "bar",
+        "variant": null
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_2d6d8b94-504c-437e-afd2-c84cc4e72b8b__default.json
+++ b/test_cases/test_2d6d8b94-504c-437e-afd2-c84cc4e72b8b__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "SPLIT; weight=30",
-        "value": "baz"
+        "value": "baz",
+        "variant": null
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_2db1db6a-2dab-4416-8510-b2a99db4f05a__default.json
+++ b/test_cases/test_2db1db6a-2dab-4416-8510-b2a99db4f05a__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": "control"
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_2dbbc953-31b3-4bf4-9f63-a09bd37baf78__default.json
+++ b/test_cases/test_2dbbc953-31b3-4bf4-9f63-a09bd37baf78__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": "control"
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_31f5d2d7-3736-478c-a887-e77c16cc8dfd__default.json
+++ b/test_cases/test_31f5d2d7-3736-478c-a887-e77c16cc8dfd__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "SPLIT; weight=30",
-        "value": "bar"
+        "value": "bar",
+        "variant": null
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_32fd6b46-69d0-4123-8e35-ca4401e8bc3e__default.json
+++ b/test_cases/test_32fd6b46-69d0-4123-8e35-ca4401e8bc3e__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": "control"
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_3719f827-9c23-4956-b82a-7c2f5102479f__default.json
+++ b/test_cases/test_3719f827-9c23-4956-b82a-7c2f5102479f__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "SPLIT; weight=30",
-        "value": "baz"
+        "value": "baz",
+        "variant": null
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_388b793f-5843-46c9-af6b-a942b52527b2__regular_segment.json
+++ b/test_cases/test_388b793f-5843-46c9-af6b-a942b52527b2__regular_segment.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "SPLIT; weight=30",
-        "value": "bar"
+        "value": "bar",
+        "variant": null
       },
       "string_feature": {
         "enabled": false,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "TARGETING_MATCH; segment=regular_segment",
-        "value": "segment_override"
+        "value": "segment_override",
+        "variant": null
       }
     },
     "segments": [

--- a/test_cases/test_397cd01d-c6a1-451c-8795-4c9686c22a3b__default.json
+++ b/test_cases/test_397cd01d-c6a1-451c-8795-4c9686c22a3b__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": "control"
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_3debf4d7-3aff-4a8e-98fe-35d3add7f9fb__default.json
+++ b/test_cases/test_3debf4d7-3aff-4a8e-98fe-35d3add7f9fb__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": "control"
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_3e06036d-fa99-4b46-a843-9bd5b1cdf171__default.json
+++ b/test_cases/test_3e06036d-fa99-4b46-a843-9bd5b1cdf171__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "SPLIT; weight=30",
-        "value": "bar"
+        "value": "bar",
+        "variant": null
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_3ecde417-838e-4469-90a9-d7e925200b51__default.json
+++ b/test_cases/test_3ecde417-838e-4469-90a9-d7e925200b51__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "SPLIT; weight=30",
-        "value": "baz"
+        "value": "baz",
+        "variant": null
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_41f0b1f5-93a1-43c0-afb7-bce9dc20aac0__default.json
+++ b/test_cases/test_41f0b1f5-93a1-43c0-afb7-bce9dc20aac0__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "SPLIT; weight=30",
-        "value": "bar"
+        "value": "bar",
+        "variant": null
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_42c798b6-1a36-4cf3-8df0-b6347020323a__default.json
+++ b/test_cases/test_42c798b6-1a36-4cf3-8df0-b6347020323a__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": "control"
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_430f2a5c-dc93-497f-be0c-859687126d95__default.json
+++ b/test_cases/test_430f2a5c-dc93-497f-be0c-859687126d95__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": "control"
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_46e87d76-34ca-410d-ac4c-67400770c398__default.json
+++ b/test_cases/test_46e87d76-34ca-410d-ac4c-67400770c398__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "SPLIT; weight=30",
-        "value": "baz"
+        "value": "baz",
+        "variant": null
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_4ab15967-c00b-4a6b-8da6-0a9ef67683fd__default.json
+++ b/test_cases/test_4ab15967-c00b-4a6b-8da6-0a9ef67683fd__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": "control"
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_4f5a88b9-2b1b-4c0a-9f9f-a3fbeda05dfb__default.json
+++ b/test_cases/test_4f5a88b9-2b1b-4c0a-9f9f-a3fbeda05dfb__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "SPLIT; weight=30",
-        "value": "baz"
+        "value": "baz",
+        "variant": null
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_53273d70-2f37-4c43-8979-e0426f7ac375__default.json
+++ b/test_cases/test_53273d70-2f37-4c43-8979-e0426f7ac375__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "SPLIT; weight=30",
-        "value": "bar"
+        "value": "bar",
+        "variant": null
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_54463d93-392f-493a-90b5-a1d3afe60f4b__default.json
+++ b/test_cases/test_54463d93-392f-493a-90b5-a1d3afe60f4b__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "SPLIT; weight=30",
-        "value": "baz"
+        "value": "baz",
+        "variant": null
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_555bb037-cc46-47de-b0fa-4bcab906f5e7__default.json
+++ b/test_cases/test_555bb037-cc46-47de-b0fa-4bcab906f5e7__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": "control"
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_560cdbac-dfd9-4536-b65b-6654d575058a__default.json
+++ b/test_cases/test_560cdbac-dfd9-4536-b65b-6654d575058a__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": "control"
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_56a8c68b-5015-47dd-97ee-0d727eb16266__default.json
+++ b/test_cases/test_56a8c68b-5015-47dd-97ee-0d727eb16266__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "SPLIT; weight=30",
-        "value": "bar"
+        "value": "bar",
+        "variant": null
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_57fd428e-b41c-4e5f-b47d-de9faed376e3__default.json
+++ b/test_cases/test_57fd428e-b41c-4e5f-b47d-de9faed376e3__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "SPLIT; weight=30",
-        "value": "bar"
+        "value": "bar",
+        "variant": null
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_5fd8e83e-bd87-42e7-8c2a-fd31960feb72__default.json
+++ b/test_cases/test_5fd8e83e-bd87-42e7-8c2a-fd31960feb72__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "SPLIT; weight=30",
-        "value": "baz"
+        "value": "baz",
+        "variant": null
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_64ebc978-1f6a-4c22-8f5b-8b0f83478ef1__default.json
+++ b/test_cases/test_64ebc978-1f6a-4c22-8f5b-8b0f83478ef1__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "SPLIT; weight=30",
-        "value": "bar"
+        "value": "bar",
+        "variant": null
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_65190952-1717-454b-bef2-b38ea62837c7__default.json
+++ b/test_cases/test_65190952-1717-454b-bef2-b38ea62837c7__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": "control"
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_65e8ea3f-6f3f-4eee-8ad5-30c7a7c7bfe4__default.json
+++ b/test_cases/test_65e8ea3f-6f3f-4eee-8ad5-30c7a7c7bfe4__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "SPLIT; weight=30",
-        "value": "bar"
+        "value": "bar",
+        "variant": null
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_67476160-7c89-4d5c-bc1a-22ef4a8b2168__default.json
+++ b/test_cases/test_67476160-7c89-4d5c-bc1a-22ef4a8b2168__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": "control"
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_70f674c4-0474-46aa-ac39-0d7a373fafca__default.json
+++ b/test_cases/test_70f674c4-0474-46aa-ac39-0d7a373fafca__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": "control"
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_7137c59d-0bc0-43d2-b1ad-492b0a03aa85__default.json
+++ b/test_cases/test_7137c59d-0bc0-43d2-b1ad-492b0a03aa85__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": "control"
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_727ae8b6-f421-453c-9310-408150fbe28c__default.json
+++ b/test_cases/test_727ae8b6-f421-453c-9310-408150fbe28c__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "SPLIT; weight=30",
-        "value": "bar"
+        "value": "bar",
+        "variant": null
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_742956df-236e-4cc9-8b55-634a7b1da4af__regular_segment.json
+++ b/test_cases/test_742956df-236e-4cc9-8b55-634a7b1da4af__regular_segment.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": "control"
       },
       "string_feature": {
         "enabled": false,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "TARGETING_MATCH; segment=regular_segment",
-        "value": "segment_override"
+        "value": "segment_override",
+        "variant": null
       }
     },
     "segments": [

--- a/test_cases/test_7765d342-16c5-4c1c-a461-459d39f65b85__default.json
+++ b/test_cases/test_7765d342-16c5-4c1c-a461-459d39f65b85__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": "control"
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_7edcfe01-784c-4951-8c22-5f84f0569381__default.json
+++ b/test_cases/test_7edcfe01-784c-4951-8c22-5f84f0569381__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": "control"
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_7fb675cf-91fc-439e-8e5f-896bbaa46319__default.json
+++ b/test_cases/test_7fb675cf-91fc-439e-8e5f-896bbaa46319__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": "control"
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_81b634c1-fde0-4d32-af2b-2ddd08d5dee6__default.json
+++ b/test_cases/test_81b634c1-fde0-4d32-af2b-2ddd08d5dee6__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "SPLIT; weight=30",
-        "value": "bar"
+        "value": "bar",
+        "variant": null
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_82cd7c27-6ae9-471e-9b8a-d9829383b489__default.json
+++ b/test_cases/test_82cd7c27-6ae9-471e-9b8a-d9829383b489__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": "control"
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_83295382-6d39-4db1-ac66-1ebb6e98b70e__default.json
+++ b/test_cases/test_83295382-6d39-4db1-ac66-1ebb6e98b70e__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": "control"
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_85457200-feeb-468a-91ac-e6397254429a__default.json
+++ b/test_cases/test_85457200-feeb-468a-91ac-e6397254429a__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "SPLIT; weight=30",
-        "value": "bar"
+        "value": "bar",
+        "variant": null
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_8e660bf8-cffa-46e3-878a-111627965710__default.json
+++ b/test_cases/test_8e660bf8-cffa-46e3-878a-111627965710__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "SPLIT; weight=30",
-        "value": "baz"
+        "value": "baz",
+        "variant": null
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_923649a9-5850-4227-a965-32d34ebf9769__default.json
+++ b/test_cases/test_923649a9-5850-4227-a965-32d34ebf9769__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "SPLIT; weight=30",
-        "value": "bar"
+        "value": "bar",
+        "variant": null
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_933949d7-b731-4f3a-a2dc-3d83d0beb1ea__default.json
+++ b/test_cases/test_933949d7-b731-4f3a-a2dc-3d83d0beb1ea__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "SPLIT; weight=30",
-        "value": "baz"
+        "value": "baz",
+        "variant": null
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_93f06180-cee7-428e-8385-1206895e4313__default.json
+++ b/test_cases/test_93f06180-cee7-428e-8385-1206895e4313__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "SPLIT; weight=30",
-        "value": "bar"
+        "value": "bar",
+        "variant": null
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_9515c224-5adc-4e44-bc39-21942779c323__default.json
+++ b/test_cases/test_9515c224-5adc-4e44-bc39-21942779c323__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": "control"
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_957d39a5-6e97-4026-9d94-be68aa97bf1b__default.json
+++ b/test_cases/test_957d39a5-6e97-4026-9d94-be68aa97bf1b__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "SPLIT; weight=30",
-        "value": "bar"
+        "value": "bar",
+        "variant": null
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_96fbbd8f-b5f4-4267-a2db-9f6848dcb20a__default.json
+++ b/test_cases/test_96fbbd8f-b5f4-4267-a2db-9f6848dcb20a__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "SPLIT; weight=30",
-        "value": "baz"
+        "value": "baz",
+        "variant": null
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_9f7d2eb7-e01c-4bec-9738-5eaeaa6bf776__default.json
+++ b/test_cases/test_9f7d2eb7-e01c-4bec-9738-5eaeaa6bf776__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": "control"
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_a2f85378-ea82-44c0-8998-be477402379c__default.json
+++ b/test_cases/test_a2f85378-ea82-44c0-8998-be477402379c__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": "control"
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_a4bc3ba0-7366-4bf2-b309-37baf2d0f45f__default.json
+++ b/test_cases/test_a4bc3ba0-7366-4bf2-b309-37baf2d0f45f__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": "control"
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_a78cf315-d2d8-4d04-b075-e9aba7421706__default.json
+++ b/test_cases/test_a78cf315-d2d8-4d04-b075-e9aba7421706__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": "control"
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_any_rule_with_nested_all_groups__no_group_matches__should_not_match.jsonc
+++ b/test_cases/test_any_rule_with_nested_all_groups__no_group_matches__should_not_match.jsonc
@@ -81,7 +81,8 @@
         "enabled": false,
         "name": "test_feature",
         "value": "default",
-        "reason": "DEFAULT"
+        "reason": "DEFAULT",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_any_rule_with_nested_all_groups__one_group_matches__should_match.jsonc
+++ b/test_cases/test_any_rule_with_nested_all_groups__one_group_matches__should_match.jsonc
@@ -81,7 +81,8 @@
         "enabled": true,
         "name": "test_feature",
         "value": "overridden",
-        "reason": "TARGETING_MATCH; segment=user_per_env"
+        "reason": "TARGETING_MATCH; segment=user_per_env",
+        "variant": null
       }
     },
     "segments": [

--- a/test_cases/test_b1cc98db-4e99-4f2c-a364-ef6382864188__default.json
+++ b/test_cases/test_b1cc98db-4e99-4f2c-a364-ef6382864188__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": "control"
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_b21bd1e2-bb87-4135-aca7-e30f465de632__default.json
+++ b/test_cases/test_b21bd1e2-bb87-4135-aca7-e30f465de632__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "SPLIT; weight=30",
-        "value": "baz"
+        "value": "baz",
+        "variant": null
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_b3305fe0-77ac-4a1b-995e-94c413c686d0__default.json
+++ b/test_cases/test_b3305fe0-77ac-4a1b-995e-94c413c686d0__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": "control"
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_b8f06d73-0430-438d-b788-d91851449908__default.json
+++ b/test_cases/test_b8f06d73-0430-438d-b788-d91851449908__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "SPLIT; weight=30",
-        "value": "bar"
+        "value": "bar",
+        "variant": null
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_be3348ec-6fd9-4b6d-a86a-fd69600855b2__default.json
+++ b/test_cases/test_be3348ec-6fd9-4b6d-a86a-fd69600855b2__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "SPLIT; weight=30",
-        "value": "bar"
+        "value": "bar",
+        "variant": null
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_c2ff801e-e145-411d-ba68-9dd2b9871bfe__default.json
+++ b/test_cases/test_c2ff801e-e145-411d-ba68-9dd2b9871bfe__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "SPLIT; weight=30",
-        "value": "baz"
+        "value": "baz",
+        "variant": null
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_c334969d-25bd-4ea2-9cd3-634fecdc542d__default.json
+++ b/test_cases/test_c334969d-25bd-4ea2-9cd3-634fecdc542d__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "SPLIT; weight=30",
-        "value": "bar"
+        "value": "bar",
+        "variant": null
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_c3483e1f-ac4e-4e1e-b398-bedde811f441__default.json
+++ b/test_cases/test_c3483e1f-ac4e-4e1e-b398-bedde811f441__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "SPLIT; weight=30",
-        "value": "baz"
+        "value": "baz",
+        "variant": null
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_c8159d13-3b99-4355-84df-c8e541d55384__default.json
+++ b/test_cases/test_c8159d13-3b99-4355-84df-c8e541d55384__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "SPLIT; weight=30",
-        "value": "bar"
+        "value": "bar",
+        "variant": null
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_c99e2bda-f55d-4964-bdd2-80ecfd00297d__default.json
+++ b/test_cases/test_c99e2bda-f55d-4964-bdd2-80ecfd00297d__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": "control"
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_cbaa7fae-9453-448a-bff1-d571be7c8a6b__default.json
+++ b/test_cases/test_cbaa7fae-9453-448a-bff1-d571be7c8a6b__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": "control"
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_ce99d7bb-2fbd-4fb3-8c4d-0f4a11c5a9aa__default.json
+++ b/test_cases/test_ce99d7bb-2fbd-4fb3-8c4d-0f4a11c5a9aa__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": "control"
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_d2a57b07-3ee1-4b0a-8cd9-e572d14635ce__default.json
+++ b/test_cases/test_d2a57b07-3ee1-4b0a-8cd9-e572d14635ce__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": "control"
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_d3f16e64-9cf8-477c-a09b-7b60723c1694__default.json
+++ b/test_cases/test_d3f16e64-9cf8-477c-a09b-7b60723c1694__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "SPLIT; weight=30",
-        "value": "bar"
+        "value": "bar",
+        "variant": null
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_d5a54a43-625b-4878-b3fa-120a2bfdd86e__default.json
+++ b/test_cases/test_d5a54a43-625b-4878-b3fa-120a2bfdd86e__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": "control"
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_d73a7a70-a8b4-4f98-978a-ebd08cbf2542__default.json
+++ b/test_cases/test_d73a7a70-a8b4-4f98-978a-ebd08cbf2542__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "SPLIT; weight=30",
-        "value": "bar"
+        "value": "bar",
+        "variant": null
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_d9b9b9e5-36aa-406e-bda6-71cb99be60f5__default.json
+++ b/test_cases/test_d9b9b9e5-36aa-406e-bda6-71cb99be60f5__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "SPLIT; weight=30",
-        "value": "bar"
+        "value": "bar",
+        "variant": null
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_db0436cb-ede2-42e4-b2d5-65af13e0852a__default.json
+++ b/test_cases/test_db0436cb-ede2-42e4-b2d5-65af13e0852a__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "SPLIT; weight=30",
-        "value": "baz"
+        "value": "baz",
+        "variant": null
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_dbcc4f61-44c2-4117-a5fd-16237b66f46d__default.json
+++ b/test_cases/test_dbcc4f61-44c2-4117-a5fd-16237b66f46d__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "SPLIT; weight=30",
-        "value": "baz"
+        "value": "baz",
+        "variant": null
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_dc6b85e3-e03b-4019-8b6d-97b1d7d25492__default.json
+++ b/test_cases/test_dc6b85e3-e03b-4019-8b6d-97b1d7d25492__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "SPLIT; weight=30",
-        "value": "baz"
+        "value": "baz",
+        "variant": null
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_e5af06dd-d3a1-4f53-9185-8989b6eaa848__default.json
+++ b/test_cases/test_e5af06dd-d3a1-4f53-9185-8989b6eaa848__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "SPLIT; weight=30",
-        "value": "baz"
+        "value": "baz",
+        "variant": null
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_e7656d90-7da5-4ce1-b647-36cd977d58fa__default.json
+++ b/test_cases/test_e7656d90-7da5-4ce1-b647-36cd977d58fa__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": "control"
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_ef981b6d-22d8-4daa-ab2d-f3f26db80a86__default.json
+++ b/test_cases/test_ef981b6d-22d8-4daa-ab2d-f3f26db80a86__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "SPLIT; weight=30",
-        "value": "bar"
+        "value": "bar",
+        "variant": null
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_efb574f7-091b-45fa-800d-ebec477efb51__default.json
+++ b/test_cases/test_efb574f7-091b-45fa-800d-ebec477efb51__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "SPLIT; weight=30",
-        "value": "bar"
+        "value": "bar",
+        "variant": null
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_f0ca10b8-7088-4336-ae8c-5332e91f1554__default.json
+++ b/test_cases/test_f0ca10b8-7088-4336-ae8c-5332e91f1554__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": "control"
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_f8fe67d7-958e-452c-a4d4-8249c8b9369c__default.json
+++ b/test_cases/test_f8fe67d7-958e-452c-a4d4-8249c8b9369c__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": "control"
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_fb098dba-4be6-4117-b95a-fd930c1598b0__default.json
+++ b/test_cases/test_fb098dba-4be6-4117-b95a-fd930c1598b0__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "SPLIT; weight=30",
-        "value": "baz"
+        "value": "baz",
+        "variant": null
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_fc300e2a-b1b8-4408-8830-676e47abaf2c__regular_segment.json
+++ b/test_cases/test_fc300e2a-b1b8-4408-8830-676e47abaf2c__regular_segment.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": "control"
       },
       "string_feature": {
         "enabled": false,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "TARGETING_MATCH; segment=regular_segment",
-        "value": "segment_override"
+        "value": "segment_override",
+        "variant": null
       }
     },
     "segments": [

--- a/test_cases/test_fe0b7a97-f9f9-4ec9-b1d8-142939493321__default.json
+++ b/test_cases/test_fe0b7a97-f9f9-4ec9-b1d8-142939493321__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "SPLIT; weight=30",
-        "value": "bar"
+        "value": "bar",
+        "variant": null
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_feature_override_with_metadata__match__metadata_in_result.jsonc
+++ b/test_cases/test_feature_override_with_metadata__match__metadata_in_result.jsonc
@@ -67,7 +67,8 @@
         "metadata": {
           "id": 12345,
           "source": "overridden"
-        }
+        },
+        "variant": null
       }
     },
     "segments": [

--- a/test_cases/test_feature_with_metadata__metadata_in_result.jsonc
+++ b/test_cases/test_feature_with_metadata__metadata_in_result.jsonc
@@ -29,7 +29,8 @@
         "value": null,
         "metadata": {
           "source": "imported"
-        }
+        },
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_ff74f26a-e832-465b-a165-375b1f70905a__default.json
+++ b/test_cases/test_ff74f26a-e832-465b-a165-375b1f70905a__default.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "SPLIT; weight=30",
-        "value": "baz"
+        "value": "baz",
+        "variant": null
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_identity_in_two_segments__segment_two__segment_three.json
+++ b/test_cases/test_identity_in_two_segments__segment_two__segment_three.json
@@ -286,35 +286,40 @@
         "metadata": {"id": 15060},
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
       "float_feature": {
         "enabled": true,
         "metadata": {"id": 15061},
         "name": "float_feature",
         "reason": "DEFAULT",
-        "value": "12.34"
+        "value": "12.34",
+        "variant": null
       },
       "integer_feature": {
         "enabled": true,
         "metadata": {"id": 15059},
         "name": "integer_feature",
         "reason": "DEFAULT",
-        "value": 1234
+        "value": 1234,
+        "variant": null
       },
       "mv_feature": {
         "enabled": true,
         "metadata": {"id": 15062},
         "name": "mv_feature",
         "reason": "SPLIT; weight=30",
-        "value": "baz"
+        "value": "baz",
+        "variant": null
       },
       "string_feature": {
         "enabled": true,
         "metadata": {"id": 15058},
         "name": "string_feature",
         "reason": "TARGETING_MATCH; segment=segment_two",
-        "value": "segment_two_override_priority_0"
+        "value": "segment_two_override_priority_0",
+        "variant": null
       }
     },
     "segments": [

--- a/test_cases/test_multivariate__explicit_identity_key__expected_allocation.jsonc
+++ b/test_cases/test_multivariate__explicit_identity_key__expected_allocation.jsonc
@@ -35,7 +35,8 @@
         "enabled": true,
         "name": "multivariate_feature",
         "reason": "SPLIT; weight=54.54",
-        "value": "variant_value"
+        "value": "variant_value",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_multivariate__no_identity_key__expected_allocation.jsonc
+++ b/test_cases/test_multivariate__no_identity_key__expected_allocation.jsonc
@@ -39,7 +39,8 @@
         "enabled": true,
         "name": "multivariate_feature",
         "reason": "SPLIT; weight=54.54",
-        "value": "variant_value"
+        "value": "variant_value",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_multivariate__option_a_stronger_priority__expected_flags.jsonc
+++ b/test_cases/test_multivariate__option_a_stronger_priority__expected_flags.jsonc
@@ -47,7 +47,8 @@
         },
         "name": "multivariate_feature",
         "reason": "SPLIT; weight=50",
-        "value": "option_a"
+        "value": "option_a",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_multivariate__option_b_stronger_priority__expected_flags.jsonc
+++ b/test_cases/test_multivariate__option_b_stronger_priority__expected_flags.jsonc
@@ -47,7 +47,8 @@
         },
         "name": "multivariate_feature",
         "reason": "SPLIT; weight=50",
-        "value": "option_b"
+        "value": "option_b",
+        "variant": null
       }
     },
     "segments": []

--- a/test_cases/test_multivariate__segment_override__expected_allocation.jsonc
+++ b/test_cases/test_multivariate__segment_override__expected_allocation.jsonc
@@ -76,7 +76,8 @@
         "name": "mv_feature",
         "enabled": true,
         "value": "50-allocation",
-        "reason": "SPLIT; weight=50"
+        "reason": "SPLIT; weight=50",
+        "variant": null
       }
     },
     "segments": [

--- a/test_cases/test_none_rule_with_nested_all_groups__match__should_exclude.jsonc
+++ b/test_cases/test_none_rule_with_nested_all_groups__match__should_exclude.jsonc
@@ -67,7 +67,8 @@
         "enabled": false,
         "name": "test_feature",
         "value": "default",
-        "reason": "DEFAULT"
+        "reason": "DEFAULT",
+        "variant": null
       }
     },
     "segments": []


### PR DESCRIPTION
## Changes

Part of the multivariate variant key work (Flagsmith/flagsmith-engine#314, Flagsmith/flagsmith#7726).

Engines now always populate a `variant` field on each flag result, mirroring OpenFeature's `ResolutionDetails.variant` (always present, nullable). This regenerates the expected results across the corpus so every flag carries it:

- `"control"` when an identity falls in a multivariate feature's **control bucket** (the leftover allocation that resolves to the default value) — 43 cases,
- the variant's **key** when a named multivariate variant is selected (none in this corpus yet — no variants carry keys),
- `null` otherwise (standard features, unkeyed variants, or evaluation without an identity) — the remaining cases.

```diff
       "mv_feature": {
         "enabled": true,
         "name": "mv_feature",
         "reason": "DEFAULT",
-        "value": "foo"
+        "value": "foo",
+        "variant": "control"
       },
       "basic_flag": {
         "enabled": false,
         "name": "basic_flag",
         "reason": "DEFAULT",
-        "value": ""
+        "value": "",
+        "variant": null
       },
```

Selection logic, weights and ordering are unchanged — this only adds the `variant` attribution. 520 result flags across the corpus (43 `"control"`, the rest `null`).

